### PR TITLE
feat(direct-io): Support direct io for predictable io performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,9 +2086,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgssapi"
@@ -4476,6 +4476,7 @@ dependencies = [
  "hdrs",
  "hyper 0.14.31",
  "jemalloc_pprof",
+ "libc",
  "log",
  "logforth",
  "mimalloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,6 +4448,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 name = "uniffle-x"
 version = "0.1.0"
 dependencies = [
+ "allocator-api2",
  "anyhow",
  "async-channel",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ strum = "0.20.0"
 strum_macros = "0.20.0"
 hdrhistogram = "7.5.4"
 libc = "0.2.169"
+allocator-api2 = "0.2"
 
 [dependencies.logforth]
 version = "0.19.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ chrono = "0.4.38"
 strum = "0.20.0"
 strum_macros = "0.20.0"
 hdrhistogram = "7.5.4"
+libc = "0.2.169"
 
 [dependencies.logforth]
 version = "0.19.1"

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -26,8 +26,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::store::local::allocator::{IoBuffer, IO_BUFFER_ALLOCATOR};
-use bytes::Bytes;
 use std::{
     fmt::{Debug, Display},
     ops::{Add, BitAnd, Not, Sub},
@@ -140,21 +138,9 @@ pub fn align_down<U: Unsigned>(align: U, v: U) -> U {
     v & !(align - U::from(1))
 }
 
-pub fn align_bytes(align: usize, data: Bytes) -> IoBuffer {
-    debug_assert_pow2(align);
-    let mut io_buffer = IoBuffer::with_capacity_in(data.len(), &IO_BUFFER_ALLOCATOR);
-    io_buffer.extend_from_slice(&data);
-    let aligned_len = align_up(align, data.len());
-    io_buffer.reserve(aligned_len - data.len());
-    unsafe { io_buffer.set_len(aligned_len) };
-    io_buffer
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::bits::{align_bytes, align_down, align_up, assert_aligned};
-    use crate::store::local::allocator::ALIGN;
-    use bytes::Bytes;
+    use crate::bits::{align_down, align_up};
 
     #[test]
     fn test_align() {
@@ -170,16 +156,5 @@ mod tests {
         let down_aligned = align_down(align, offset);
         assert_eq!(4096, up_aligned);
         assert_eq!(4096, down_aligned);
-    }
-
-    #[test]
-    fn test_align_bytes() {
-        let raw_data = vec![b'x'; 8];
-        let data = Bytes::from(raw_data.clone());
-
-        let aligned = align_bytes(ALIGN, data);
-        assert_eq!(ALIGN, aligned.len());
-
-        assert_aligned(ALIGN, aligned.as_ptr() as _);
     }
 }

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -151,9 +151,8 @@ pub fn align_bytes(align: usize, data: Bytes) -> Bytes {
 
 #[cfg(test)]
 mod tests {
-    use crate::bits::align_up;
     use bytes::Bytes;
-    use uniffle_worker::bits::{align_bytes, align_down};
+    use crate::bits::{align_up, align_bytes, align_down};
 
     #[test]
     fn test_align() {

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,0 +1,178 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::{Bytes, BytesMut};
+use std::{
+    fmt::{Debug, Display},
+    ops::{Add, BitAnd, Not, Sub},
+};
+// TODO(MrCroxx): Use `trait_alias` after stable.
+// pub trait UnsignedTrait = Add<Output = Self>
+//     + Sub<Output = Self>
+//     + BitAnd<Output = Self>
+//     + Not<Output = Self>
+//     + Sized
+//     + From<u8>
+//     + Eq
+//     + Debug
+//     + Display
+//     + Clone
+//     + Copy;
+
+/// An unsigned trait that used by the utils.
+pub trait Unsigned:
+    Add<Output = Self>
+    + Sub<Output = Self>
+    + BitAnd<Output = Self>
+    + Not<Output = Self>
+    + Sized
+    + From<u8>
+    + Eq
+    + Debug
+    + Display
+    + Clone
+    + Copy
+{
+}
+
+impl<
+        U: Add<Output = Self>
+            + Sub<Output = Self>
+            + BitAnd<Output = Self>
+            + Not<Output = Self>
+            + Sized
+            + From<u8>
+            + Eq
+            + Debug
+            + Display
+            + Clone
+            + Copy,
+    > Unsigned for U
+{
+}
+
+/// Check if the given value is a power of 2.
+#[inline(always)]
+pub fn is_pow2<U: Unsigned>(v: U) -> bool {
+    v & (v - U::from(1)) == U::from(0)
+}
+
+/// Assert that the given value is a power of 2.
+#[inline(always)]
+pub fn assert_pow2<U: Unsigned>(v: U) {
+    assert_eq!(v & (v - U::from(1)), U::from(0), "v: {}", v);
+}
+
+/// Debug assert that the given value is a power of 2.
+#[inline(always)]
+pub fn debug_assert_pow2<U: Unsigned>(v: U) {
+    debug_assert_eq!(v & (v - U::from(1)), U::from(0), "v: {}", v);
+}
+
+/// Check if the given value is aligend with the given align.
+///
+/// Note: The given align must be a power of 2.
+#[inline(always)]
+pub fn is_aligned<U: Unsigned>(align: U, v: U) -> bool {
+    debug_assert_pow2(align);
+    v & (align - U::from(1)) == U::from(0)
+}
+
+/// Assert that the given value is aligend with the given align.
+///
+/// Note: The given align must be a power of 2.
+#[inline(always)]
+pub fn assert_aligned<U: Unsigned>(align: U, v: U) {
+    debug_assert_pow2(align);
+    assert!(is_aligned(align, v), "align: {}, v: {}", align, v);
+}
+
+/// Debug assert that the given value is aligend with the given align.
+///
+/// Note: The given align must be a power of 2.
+#[inline(always)]
+pub fn debug_assert_aligned<U: Unsigned>(align: U, v: U) {
+    debug_assert_pow2(align);
+    debug_assert!(is_aligned(align, v), "align: {}, v: {}", align, v);
+}
+
+/// Align up the given value with the given align.
+///
+/// Note: The given align must be a power of 2.
+#[inline(always)]
+pub fn align_up<U: Unsigned>(align: U, v: U) -> U {
+    debug_assert_pow2(align);
+    (v + align - U::from(1)) & !(align - U::from(1))
+}
+
+/// Align down the given value with the given align.
+///
+/// Note: The given align must be a power of 2.
+#[inline(always)]
+pub fn align_down<U: Unsigned>(align: U, v: U) -> U {
+    debug_assert_pow2(align);
+    v & !(align - U::from(1))
+}
+
+pub fn align_bytes(align: usize, data: Bytes) -> Bytes {
+    debug_assert_pow2(align);
+    let aligned_len = align_up(align, data.len());
+    let mut aligned_bytes = BytesMut::with_capacity(aligned_len);
+    aligned_bytes.extend_from_slice(&data);
+    aligned_bytes.reserve(aligned_len - data.len());
+    unsafe { aligned_bytes.set_len(aligned_len) };
+    aligned_bytes.freeze()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bits::align_up;
+    use bytes::Bytes;
+    use uniffle_worker::bits::{align_bytes, align_down};
+
+    #[test]
+    fn test_align() {
+        let align = 4096;
+        let offset = 4097;
+        let up_aligned = align_up(align, offset);
+        let down_aligned = align_down(align, offset);
+        assert_eq!(8192, up_aligned);
+        assert_eq!(4096, down_aligned);
+    }
+
+    #[test]
+    fn test_align_bytes() {
+        let raw_data = vec![b'x'; 8];
+        let data = Bytes::from(raw_data.clone());
+        let align = 4096;
+
+        let aligned = align_bytes(align, data);
+        assert_eq!(align, aligned.len());
+        assert_eq!(raw_data, aligned.slice(0..8));
+    }
+}

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -164,6 +164,12 @@ mod tests {
         let down_aligned = align_down(align, offset);
         assert_eq!(8192, up_aligned);
         assert_eq!(4096, down_aligned);
+
+        let offset = 4096;
+        let up_aligned = align_up(align, offset);
+        let down_aligned = align_down(align, offset);
+        assert_eq!(4096, up_aligned);
+        assert_eq!(4096, down_aligned);
     }
 
     #[test]

--- a/src/composed_bytes.rs
+++ b/src/composed_bytes.rs
@@ -40,6 +40,10 @@ impl ComposedBytes {
         self.composed.iter()
     }
 
+    pub fn to_vec(self) -> Vec<Bytes> {
+        self.composed
+    }
+
     pub fn len(&self) -> usize {
         self.total_len
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,13 @@ pub struct LocalfileStoreConfig {
     pub disk_healthy_check_interval_sec: u64,
 
     pub io_scheduler_config: Option<IoSchedulerConfig>,
+
+    #[serde(default = "as_default_direct_io_enable")]
+    pub direct_io_enable: bool,
+}
+
+fn as_default_direct_io_enable() -> bool {
+    false
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -159,6 +166,7 @@ impl LocalfileStoreConfig {
             disk_read_buf_capacity: as_default_disk_read_buf_capacity(),
             disk_healthy_check_interval_sec: as_default_disk_healthy_check_interval_sec(),
             io_scheduler_config: None,
+            direct_io_enable: as_default_direct_io_enable(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ mod reject;
 pub mod semaphore_with_index;
 pub mod storage;
 
+pub mod bits;
 pub mod histogram;
 
 use crate::app::{AppManager, AppManagerRef};

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ mod log_service;
 #[cfg(feature = "logforth")]
 mod logforth_service;
 
+pub mod bits;
 pub mod histogram;
 mod mem_allocator;
 mod metric;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -218,6 +218,26 @@ pub static LOCALFILE_DISK_READ_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::ne
     opts
 });
 
+pub static LOCALFILE_DISK_DIRECT_APPEND_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    let opts = histogram_opts!(
+        "localfile_disk_direct_append_operation_duration",
+        "localfile disk direct append time",
+        Vec::from(DEFAULT_BUCKETS)
+    );
+    let opts = register_histogram_vec_with_registry!(opts, &["root"], REGISTRY).unwrap();
+    opts
+});
+
+pub static LOCALFILE_DISK_DIRECT_READ_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    let opts = histogram_opts!(
+        "localfile_disk_direct_read_operation_duration",
+        "localfile disk direct read time",
+        Vec::from(DEFAULT_BUCKETS)
+    );
+    let opts = register_histogram_vec_with_registry!(opts, &["root"], REGISTRY).unwrap();
+    opts
+});
+
 pub static LOCALFILE_DISK_DELETE_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     let opts = histogram_opts!(
         "localfile_disk_delete_operation_duration",

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -54,6 +54,14 @@ const SPILL_BATCH_SIZE_BUCKETS: &[f64] = &[
 
 pub static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
 
+pub static ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "alignment_buffer_pool_read_acquire_miss",
+        "alignment_buffer_pool_read_acquire_miss",
+    )
+    .expect("metric should be created")
+});
+
 pub static LOCALFILE_READ_MEMORY_ALLOCATION_LATENCY: Lazy<histogram::Histogram> =
     Lazy::new(|| histogram::Histogram::new("localfile_read_memory_allocation_latency"));
 
@@ -640,6 +648,9 @@ pub static IO_SCHEDULER_APPEND_WAIT: Lazy<IntGaugeVec> =
     Lazy::new(|| register_int_gauge_vec!("append_wait", "append_wait", &["root"]).unwrap());
 
 fn register_custom_metrics() {
+    REGISTRY
+        .register(Box::new(ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS.clone()))
+        .expect("");
     REGISTRY
         .register(Box::new(IO_SCHEDULER_READ_PERMITS.clone()))
         .expect("");

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -62,6 +62,14 @@ pub static ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS: Lazy<IntCounter> = Lazy::new
     .expect("metric should be created")
 });
 
+pub static ALIGNMENT_BUFFER_POOL_ACQUIRED_MISS: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        "alignment_buffer_pool_acquired_miss",
+        "alignment_buffer_pool_acquired_miss",
+    )
+    .expect("metric should be created")
+});
+
 pub static ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER: Lazy<IntGauge> = Lazy::new(|| {
     IntGauge::new(
         "alignment_buffer_pool_acquired_buffer",
@@ -656,6 +664,9 @@ pub static IO_SCHEDULER_APPEND_WAIT: Lazy<IntGaugeVec> =
     Lazy::new(|| register_int_gauge_vec!("append_wait", "append_wait", &["root"]).unwrap());
 
 fn register_custom_metrics() {
+    REGISTRY
+        .register(Box::new(ALIGNMENT_BUFFER_POOL_ACQUIRED_MISS.clone()))
+        .expect("");
     REGISTRY
         .register(Box::new(ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER.clone()))
         .expect("");

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -62,6 +62,14 @@ pub static ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS: Lazy<IntCounter> = Lazy::new
     .expect("metric should be created")
 });
 
+pub static ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        "alignment_buffer_pool_acquired_buffer",
+        "alignment_buffer_pool_acquired_buffer",
+    )
+    .expect("metric should be created")
+});
+
 pub static LOCALFILE_READ_MEMORY_ALLOCATION_LATENCY: Lazy<histogram::Histogram> =
     Lazy::new(|| histogram::Histogram::new("localfile_read_memory_allocation_latency"));
 
@@ -648,6 +656,9 @@ pub static IO_SCHEDULER_APPEND_WAIT: Lazy<IntGaugeVec> =
     Lazy::new(|| register_int_gauge_vec!("append_wait", "append_wait", &["root"]).unwrap());
 
 fn register_custom_metrics() {
+    REGISTRY
+        .register(Box::new(ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER.clone()))
+        .expect("");
     REGISTRY
         .register(Box::new(ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS.clone()))
         .expect("");

--- a/src/store/alignment/io_buffer_pool.rs
+++ b/src/store/alignment/io_buffer_pool.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 use crate::bits;
+use crate::metric::ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER;
 use crate::store::alignment::io_bytes::{IoBuffer, IoBytes};
 use crate::store::alignment::ALIGN;
 use crossbeam::queue::ArrayQueue;
@@ -60,6 +61,7 @@ impl IoBufferPool {
             None => create(),
         };
         assert_eq!(res.len(), self.buffer_size);
+        ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER.inc();
         res
     }
 
@@ -67,6 +69,7 @@ impl IoBufferPool {
         if self.queue.len() < self.capacity {
             let _ = self.queue.push(buffer.into());
         }
+        ALIGNMENT_BUFFER_POOL_ACQUIRED_BUFFER.dec();
     }
 
     pub fn buffer_size(&self) -> usize {

--- a/src/store/alignment/io_buffer_pool.rs
+++ b/src/store/alignment/io_buffer_pool.rs
@@ -1,0 +1,75 @@
+//  Copyright 2024 foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::bits;
+use crate::store::alignment::io_bytes::{IoBuffer, IoBytes};
+use crate::store::alignment::ALIGN;
+use crossbeam::queue::ArrayQueue;
+
+#[derive(Debug)]
+enum Buffer {
+    IoBuffer(IoBuffer),
+    IoBytes(IoBytes),
+}
+
+impl From<IoBuffer> for Buffer {
+    fn from(value: IoBuffer) -> Self {
+        Self::IoBuffer(value)
+    }
+}
+
+impl From<IoBytes> for Buffer {
+    fn from(value: IoBytes) -> Self {
+        Self::IoBytes(value)
+    }
+}
+
+#[derive(Debug)]
+pub struct IoBufferPool {
+    capacity: usize,
+    buffer_size: usize,
+    queue: ArrayQueue<Buffer>,
+}
+
+impl IoBufferPool {
+    pub fn new(buffer_size: usize, capacity: usize) -> Self {
+        bits::assert_aligned(ALIGN, buffer_size);
+        Self {
+            capacity,
+            buffer_size,
+            queue: ArrayQueue::new(capacity),
+        }
+    }
+
+    pub fn acquire(&self) -> IoBuffer {
+        let create = || IoBuffer::new(self.buffer_size);
+        let res = match self.queue.pop() {
+            Some(Buffer::IoBuffer(buffer)) => buffer,
+            Some(Buffer::IoBytes(bytes)) => bytes.into_io_buffer().unwrap_or_else(create),
+            None => create(),
+        };
+        assert_eq!(res.len(), self.buffer_size);
+        res
+    }
+
+    pub fn release(&self, buffer: impl Into<Buffer>) {
+        if self.queue.len() < self.capacity {
+            let _ = self.queue.push(buffer.into());
+        }
+    }
+
+    pub fn buffer_size(&self) -> usize {
+        self.buffer_size
+    }
+}

--- a/src/store/alignment/io_bytes.rs
+++ b/src/store/alignment/io_bytes.rs
@@ -1,0 +1,468 @@
+//  Copyright 2024 foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::bits;
+use crate::store::alignment::allocator::AlignedAllocator;
+use crate::store::alignment::{ALIGN, IO_BUFFER_ALLOCATOR};
+use allocator_api2::{boxed::Box as BoxA, vec::Vec as VecA};
+use bytes::{buf::UninitSlice, Buf, BufMut};
+use std::{
+    fmt::Debug,
+    ops::{Bound, Deref, DerefMut, RangeBounds},
+    sync::Arc,
+};
+
+/// A capacity-fixed 4K-aligned u8 buffer.
+pub struct IoBuffer {
+    inner: BoxA<[u8], &'static AlignedAllocator<ALIGN>>,
+}
+
+impl Debug for IoBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&*self.inner, f)
+    }
+}
+
+impl IoBuffer {
+    /// Constructs a new 4K-aligned [`IoBuffer`] with at least the specified capacity.
+    ///
+    /// The buffer is filled with random data.
+    pub fn new(size: usize) -> Self {
+        let size = bits::align_up(ALIGN, size);
+        let mut v = VecA::with_capacity_in(size, &IO_BUFFER_ALLOCATOR);
+        let aligned = bits::align_down(ALIGN, v.capacity());
+        unsafe { v.set_len(aligned) };
+        let inner = v.into_boxed_slice();
+        Self { inner }
+    }
+}
+
+impl Deref for IoBuffer {
+    type Target = BoxA<[u8], &'static AlignedAllocator<ALIGN>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for IoBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl PartialEq for IoBuffer {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for IoBuffer {}
+
+impl Clone for IoBuffer {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// A 4K-aligned u8 vector.
+///
+/// # Growth
+///
+/// [`IoBytesMut`] will implicitly grow its buffer as necessary.
+/// However, explicitly reserving the required space up-front before a series of inserts will be more efficient.
+pub struct IoBytesMut {
+    inner: VecA<u8, &'static AlignedAllocator<ALIGN>>,
+}
+
+impl Debug for IoBytesMut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&*self.inner, f)
+    }
+}
+
+impl From<VecA<u8, &'static AlignedAllocator<ALIGN>>> for IoBytesMut {
+    fn from(value: VecA<u8, &'static AlignedAllocator<ALIGN>>) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl Default for IoBytesMut {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for IoBytesMut {
+    type Target = VecA<u8, &'static AlignedAllocator<ALIGN>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for IoBytesMut {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl PartialEq for IoBytesMut {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for IoBytesMut {}
+
+impl Clone for IoBytesMut {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl std::io::Write for IoBytesMut {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        let len = bufs.iter().map(|b| b.len()).sum();
+        self.reserve(len);
+        for buf in bufs {
+            self.extend_from_slice(buf);
+        }
+        Ok(len)
+    }
+
+    // TODO(MrCroxx): Uncomment this after `can_vector` is stable.
+    // #[inline]
+    // fn is_write_vectored(&self) -> bool {
+    //     true
+    // }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Ported from `bytes`.
+unsafe impl BufMut for IoBytesMut {
+    #[inline]
+    fn remaining_mut(&self) -> usize {
+        // A vector can never have more than isize::MAX bytes
+        isize::MAX as usize - self.len()
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        let len = self.len();
+        let remaining = self.capacity() - len;
+
+        if remaining < cnt {
+            panic_advance(cnt, remaining);
+        }
+
+        // Addition will not overflow since the sum is at most the capacity.
+        self.set_len(len + cnt);
+    }
+
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        if self.capacity() == self.len() {
+            self.reserve(64); // Grow the vec
+        }
+
+        let cap = self.capacity();
+        let len = self.len();
+
+        let ptr = self.as_mut_ptr();
+        // SAFETY: Since `ptr` is valid for `cap` bytes, `ptr.add(len)` must be
+        // valid for `cap - len` bytes. The subtraction will not underflow since
+        // `len <= cap`.
+        unsafe { UninitSlice::from_raw_parts_mut(ptr.add(len), cap - len) }
+    }
+
+    // Specialize these methods so they can skip checking `remaining_mut`
+    // and `advance_mut`.
+    #[inline]
+    fn put<T: Buf>(&mut self, mut src: T)
+    where
+        Self: Sized,
+    {
+        // In case the src isn't contiguous, reserve upfront.
+        self.reserve(src.remaining());
+
+        while src.has_remaining() {
+            let s = src.chunk();
+            let l = s.len();
+            self.extend_from_slice(s);
+            src.advance(l);
+        }
+    }
+
+    #[inline]
+    fn put_slice(&mut self, src: &[u8]) {
+        self.extend_from_slice(src);
+    }
+
+    #[inline]
+    fn put_bytes(&mut self, val: u8, cnt: usize) {
+        // If the addition overflows, then the `resize` will fail.
+        let new_len = self.len().saturating_add(cnt);
+        self.resize(new_len, val);
+    }
+}
+
+/// Panic with a nice error message.
+///
+/// Ported from `bytes`.
+#[cold]
+fn panic_advance(idx: usize, len: usize) -> ! {
+    panic!(
+        "advance out of bounds: the len is {} but advancing by {}",
+        len, idx
+    );
+}
+
+impl IoBytesMut {
+    /// Constructs a new, empty 4K-aligned u8 vector.
+    pub fn new() -> Self {
+        Self {
+            inner: VecA::new_in(&IO_BUFFER_ALLOCATOR),
+        }
+    }
+
+    /// Constructs a new, empty , empty 4K-aligned u8 vector
+    /// with at least the specified capacity with the provided allocator.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: VecA::with_capacity_in(capacity, &IO_BUFFER_ALLOCATOR),
+        }
+    }
+
+    // Splits the collection into two at the given index.
+    ///
+    /// Returns a newly allocated vector containing the elements in the range
+    /// `[at, len)`. After the call, the original vector will be left containing
+    /// the elements `[0, at)` with its previous capacity unchanged.
+    ///
+    /// # Panics
+    ///
+    /// The split point `at` must be 4K-aligned.
+    pub fn split_off(&mut self, at: usize) -> Self {
+        debug_assert_eq!(at % ALIGN, 0);
+        let inner = self.inner.split_off(at);
+        Self { inner }
+    }
+
+    /// Align the length of the vector to 4K.
+    ///
+    /// The extended part of the vector can be filled with any data without any guarantees.
+    pub fn align_to(&mut self) {
+        let aligned = bits::align_up(ALIGN, self.inner.len());
+        self.inner.reserve_exact(aligned - self.inner.len());
+        unsafe { self.inner.set_len(aligned) };
+    }
+
+    /// Convert [`IoBytesMut`] to [`IoBytes`].
+    pub fn freeze(self) -> IoBytes {
+        self.into()
+    }
+}
+
+/// A 4K-aligned, shared, immutable u8 vector.
+pub struct IoBytes {
+    inner: Arc<BoxA<[u8], &'static AlignedAllocator<ALIGN>>>,
+    offset: usize,
+    len: usize,
+}
+
+impl Debug for IoBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&*self.inner, f)
+    }
+}
+
+impl From<VecA<u8, &'static AlignedAllocator<ALIGN>>> for IoBytes {
+    fn from(mut value: VecA<u8, &'static AlignedAllocator<ALIGN>>) -> Self {
+        let offset = 0;
+        let len = value.len();
+
+        let aligned = bits::align_up(ALIGN, value.len());
+        value.reserve_exact(aligned - value.len());
+        unsafe { value.set_len(aligned) };
+
+        let inner = value.into_boxed_slice();
+        let inner = Arc::new(inner);
+
+        Self { inner, offset, len }
+    }
+}
+
+impl From<IoBytesMut> for IoBytes {
+    fn from(value: IoBytesMut) -> Self {
+        value.inner.into()
+    }
+}
+
+impl From<IoBuffer> for IoBytes {
+    fn from(value: IoBuffer) -> Self {
+        assert!(bits::is_aligned(ALIGN, value.len()));
+        let offset = 0;
+        let len = value.len();
+        let inner = Arc::new(value.inner);
+        Self { inner, offset, len }
+    }
+}
+
+impl Default for IoBytes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for IoBytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner[self.offset..self.offset + self.len]
+    }
+}
+
+impl PartialEq for IoBytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for IoBytes {}
+
+impl Clone for IoBytes {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            offset: self.offset,
+            len: self.len,
+        }
+    }
+}
+
+impl IoBytes {
+    /// Constructs a new, empty, shared 4K-aligned u8 vector.
+    pub fn new() -> Self {
+        IoBytesMut::new().into()
+    }
+
+    /// Returns a 4K-aligned slice of self for the provided range.
+    ///
+    /// # Panics
+    ///
+    /// - The range must be valid.
+    /// - The new slice must still be 4K-aligned.
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> Self {
+        let start = match range.start_bound() {
+            Bound::Included(i) => self.offset + *i,
+            Bound::Excluded(i) => self.offset + *i + 1,
+            Bound::Unbounded => self.offset,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(i) => self.offset + *i + 1,
+            Bound::Excluded(i) => self.offset + *i,
+            Bound::Unbounded => self.offset + self.len,
+        };
+        assert_eq!(start % ALIGN, 0);
+        if start > end || start < self.offset || end > self.offset + self.len {
+            panic!("slice index out of bound");
+        }
+        Self {
+            inner: self.inner.clone(),
+            offset: start,
+            len: end - start,
+        }
+    }
+
+    /// As 4K-aligned u8 slice.
+    ///
+    /// For the underlying vector has reserved aligned size when creating,
+    /// this operation is always safe.
+    pub fn as_aligned(&self) -> &[u8] {
+        let start = self.offset;
+        let end = bits::align_up(ALIGN, self.offset + self.len);
+        debug_assert_eq!(start % ALIGN, 0);
+        debug_assert_eq!(end % ALIGN, 0);
+        &self.inner[start..end]
+    }
+
+    /// Returns the underlying buffer as [`IoBuffer`], if the [`IoBytes`] has exactly one reference.
+    ///
+    /// Otherwise, an [`Err`] is returned with the same [`IoBytes`] that was passed in.
+    ///
+    /// Note: The [`IoBytes`] can be a slice of the underlying [`IoBuffer`].
+    /// `try_into_io_buffer` always returns the original complete underlying [`IoBuffer`].
+    pub fn try_into_io_buffer(self) -> core::result::Result<IoBuffer, Self> {
+        match Arc::try_unwrap(self.inner) {
+            Ok(inner) => Ok(IoBuffer { inner }),
+            Err(inner) => Err(Self {
+                inner,
+                offset: self.offset,
+                len: self.len,
+            }),
+        }
+    }
+
+    /// Returns the underlying buffer as [`IoBuffer`], if the [`IoBytes`] has exactly one reference.
+    ///
+    /// Otherwise, [`None`] is returned.
+    ///
+    /// It is strongly recommended to use `into_io_buffer` instead if you don't want to keep the original [`IoBytes`]
+    /// in the [`Err`] path. See `Arc::try_unwrap` and `Arc::into_inner` docs.
+    ///
+    /// Note: The [`IoBytes`] can be a slice of the underlying [`IoBuffer`].
+    /// `try_into_io_buffer` always returns the original complete underlying [`IoBuffer`].
+    pub fn into_io_buffer(self) -> Option<IoBuffer> {
+        Arc::into_inner(self.inner).map(|inner| IoBuffer { inner })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_io_bytes() {
+        let mut buf = IoBytesMut::new();
+        buf.put_slice(&[42; 1024]);
+        assert_eq!(buf.as_ptr() as usize % ALIGN, 0);
+
+        let buf = buf.freeze();
+        assert_eq!(buf.len(), 1024);
+        assert_eq!(buf.as_aligned().len(), ALIGN);
+        let buf = buf.slice(..42);
+        assert_eq!(buf.len(), 42);
+        assert_eq!(buf.as_aligned().len(), ALIGN);
+    }
+}

--- a/src/store/alignment/mod.rs
+++ b/src/store/alignment/mod.rs
@@ -1,0 +1,8 @@
+use crate::store::alignment::allocator::AlignedAllocator;
+
+pub mod allocator;
+pub mod io_buffer_pool;
+pub mod io_bytes;
+
+pub const ALIGN: usize = 4096;
+pub const IO_BUFFER_ALLOCATOR: AlignedAllocator<ALIGN> = AlignedAllocator::new();

--- a/src/store/local/allocator.rs
+++ b/src/store/local/allocator.rs
@@ -1,0 +1,124 @@
+//  Copyright 2024 Foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::ops::{Deref, DerefMut};
+
+use allocator_api2::alloc::{AllocError, Allocator, Global};
+
+pub use allocator_api2::vec::Vec as VecA;
+pub const ALIGN: usize = 4096;
+pub const IO_BUFFER_ALLOCATOR: AlignedAllocator<ALIGN> = AlignedAllocator::new();
+
+pub type IoBuffer = allocator_api2::vec::Vec<u8, &'static AlignedAllocator<ALIGN>>;
+
+#[derive(Debug)]
+pub struct WritableVecA<'a, T, A: Allocator = Global>(pub &'a mut VecA<T, A>);
+
+impl<'a, T, A: Allocator> Deref for WritableVecA<'a, T, A> {
+    type Target = VecA<T, A>;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, T, A: Allocator> DerefMut for WritableVecA<'a, T, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+    }
+}
+
+impl<'a, A: Allocator> std::io::Write for WritableVecA<'a, u8, A> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        let len = bufs.iter().map(|b| b.len()).sum();
+        self.0.reserve(len);
+        for buf in bufs {
+            self.0.extend_from_slice(buf);
+        }
+        Ok(len)
+    }
+
+    // TODO(MrCroxx): Uncomment this after `can_vector` is stable.
+    // #[inline]
+    // fn is_write_vectored(&self) -> bool {
+    //     true
+    // }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.0.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AlignedAllocator<const N: usize>;
+
+impl<const N: usize> Default for AlignedAllocator<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> AlignedAllocator<N> {
+    pub const fn new() -> Self {
+        assert!(N.is_power_of_two());
+        Self
+    }
+}
+
+unsafe impl<const N: usize> Allocator for AlignedAllocator<N> {
+    fn allocate(&self, layout: std::alloc::Layout) -> Result<std::ptr::NonNull<[u8]>, AllocError> {
+        Global.allocate(layout.align_to(N).unwrap())
+    }
+
+    unsafe fn deallocate(&self, ptr: std::ptr::NonNull<u8>, layout: std::alloc::Layout) {
+        Global.deallocate(ptr, layout.align_to(N).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits;
+
+    #[test]
+    fn test_aligned_buffer() {
+        const ALIGN: usize = 512;
+        let allocator = AlignedAllocator::<ALIGN>::new();
+
+        let mut buf: VecA<u8, _> = VecA::with_capacity_in(ALIGN * 8, &allocator);
+        bits::assert_aligned(ALIGN, buf.as_ptr() as _);
+
+        buf.extend_from_slice(&[b'x'; ALIGN * 8]);
+        bits::assert_aligned(ALIGN, buf.as_ptr() as _);
+        assert_eq!(buf, [b'x'; ALIGN * 8]);
+
+        buf.extend_from_slice(&[b'x'; ALIGN * 8]);
+        bits::assert_aligned(ALIGN, buf.as_ptr() as _);
+        assert_eq!(buf, [b'x'; ALIGN * 16])
+    }
+}

--- a/src/store/local/delegator.rs
+++ b/src/store/local/delegator.rs
@@ -339,11 +339,19 @@ impl LocalIO for LocalDiskDelegator {
         Ok(file_stat)
     }
 
-    async fn direct_append(&self, path: &str, data: BytesWrapper) -> Result<u64, WorkerError> {
+    async fn direct_append(
+        &self,
+        path: &str,
+        written_bytes: usize,
+        data: BytesWrapper,
+    ) -> Result<(), WorkerError> {
         let timer = LOCALFILE_DISK_DIRECT_APPEND_OPERATION_DURATION
             .with_label_values(&[&self.inner.root])
             .start_timer();
-        self.inner.io_handler.direct_append(path, data).await
+        self.inner
+            .io_handler
+            .direct_append(path, written_bytes, data)
+            .await
     }
 
     async fn direct_read(

--- a/src/store/local/mod.rs
+++ b/src/store/local/mod.rs
@@ -21,6 +21,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 
+pub mod allocator;
 pub mod async_io;
 pub mod delegator;
 mod scheduler;

--- a/src/store/local/mod.rs
+++ b/src/store/local/mod.rs
@@ -21,12 +21,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-pub mod allocator;
 pub mod async_io;
 pub mod delegator;
 mod scheduler;
 pub mod sync_io;
-
 pub struct FileStat {
     pub content_length: u64,
 }

--- a/src/store/local/mod.rs
+++ b/src/store/local/mod.rs
@@ -45,7 +45,12 @@ pub trait LocalIO: Clone {
     async fn write(&self, path: &str, data: Bytes) -> Result<(), WorkerError>;
     async fn file_stat(&self, path: &str) -> Result<FileStat, WorkerError>;
 
-    async fn direct_append(&self, path: &str, data: BytesWrapper) -> Result<u64, WorkerError>;
+    async fn direct_append(
+        &self,
+        path: &str,
+        written_bytes: usize,
+        data: BytesWrapper,
+    ) -> Result<(), WorkerError>;
     async fn direct_read(&self, path: &str, offset: i64, length: i64)
         -> Result<Bytes, WorkerError>;
 }

--- a/src/store/local/mod.rs
+++ b/src/store/local/mod.rs
@@ -43,6 +43,10 @@ pub trait LocalIO: Clone {
     async fn delete(&self, path: &str) -> Result<(), WorkerError>;
     async fn write(&self, path: &str, data: Bytes) -> Result<(), WorkerError>;
     async fn file_stat(&self, path: &str) -> Result<FileStat, WorkerError>;
+
+    async fn direct_append(&self, path: &str, data: BytesWrapper) -> Result<u64, WorkerError>;
+    async fn direct_read(&self, path: &str, offset: i64, length: i64)
+        -> Result<Bytes, WorkerError>;
 }
 
 pub trait LocalDiskStorage: LocalIO {

--- a/src/store/local/sync_io.rs
+++ b/src/store/local/sync_io.rs
@@ -2,6 +2,7 @@ use crate::bits::{align_bytes, align_down, align_up};
 use crate::error::WorkerError;
 use crate::metric::LOCALFILE_READ_MEMORY_ALLOCATION_LATENCY;
 use crate::runtime::RuntimeRef;
+use crate::store::local::allocator::ALIGN;
 use crate::store::local::{FileStat, LocalIO};
 use crate::store::BytesWrapper;
 use anyhow::anyhow;
@@ -14,8 +15,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use std::{fs, io};
-
-pub const ALIGN: usize = 4096;
 
 #[derive(Clone)]
 pub struct SyncLocalIO {

--- a/src/store/local/sync_io.rs
+++ b/src/store/local/sync_io.rs
@@ -1,7 +1,9 @@
 use crate::bits::is_aligned;
 use crate::bits::{align_down, align_up};
 use crate::error::WorkerError;
-use crate::metric::LOCALFILE_READ_MEMORY_ALLOCATION_LATENCY;
+use crate::metric::{
+    ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS, LOCALFILE_READ_MEMORY_ALLOCATION_LATENCY,
+};
 use crate::runtime::RuntimeRef;
 use crate::store::alignment::io_buffer_pool::IoBufferPool;
 use crate::store::alignment::io_bytes::IoBuffer;
@@ -132,6 +134,7 @@ fn inner_direct_read(path: &str, offset: i64, len: i64) -> Result<Bytes, Error> 
         buf_from_pool = true;
         (IO_BUFFER_POOL.acquire(), IO_BUFFER_POOL.buffer_size())
     } else {
+        ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS.inc();
         (IoBuffer::new(range), range)
     };
     // only gotten the min range buf to reduce io range access

--- a/src/store/local/sync_io.rs
+++ b/src/store/local/sync_io.rs
@@ -134,6 +134,8 @@ fn inner_direct_read(path: &str, offset: i64, len: i64) -> Result<Bytes, Error> 
         buf_from_pool = true;
         (IO_BUFFER_POOL.acquire(), IO_BUFFER_POOL.buffer_size())
     } else {
+        /// todo: if the required data len > pool buffer size, it can split to multi
+        /// access to reuse the aligned buffer to reduce system load.
         ALIGNMENT_BUFFER_POOL_READ_ACQUIRE_MISS.inc();
         (IoBuffer::new(range), range)
     };

--- a/src/store/local/sync_io.rs
+++ b/src/store/local/sync_io.rs
@@ -1,8 +1,11 @@
-use crate::bits::{align_bytes, align_down, align_up};
+use crate::bits::is_aligned;
+use crate::bits::{align_down, align_up};
 use crate::error::WorkerError;
 use crate::metric::LOCALFILE_READ_MEMORY_ALLOCATION_LATENCY;
 use crate::runtime::RuntimeRef;
-use crate::store::local::allocator::{IoBuffer, ALIGN, IO_BUFFER_ALLOCATOR};
+use crate::store::alignment::io_buffer_pool::IoBufferPool;
+use crate::store::alignment::io_bytes::IoBuffer;
+use crate::store::alignment::{ALIGN, IO_BUFFER_ALLOCATOR};
 use crate::store::local::{FileStat, LocalIO};
 use crate::store::BytesWrapper;
 use allocator_api2::SliceExt;
@@ -11,12 +14,18 @@ use async_trait::async_trait;
 use await_tree::InstrumentAwait;
 use bytes::{Bytes, BytesMut};
 use log::debug;
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Error, Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use std::{fs, io};
+
+static IO_BUFFER_POOL: Lazy<IoBufferPool> =
+    Lazy::new(|| IoBufferPool::new(ALIGN * 1024 * 4, 64 * 4));
 
 #[derive(Clone)]
 pub struct SyncLocalIO {
@@ -57,15 +66,76 @@ impl SyncLocalIO {
     }
 }
 
-pub fn inner_direct_read(path: &str, offset: i64, len: i64) -> Result<Bytes, Error> {
+fn fill_buffer_and_write(
+    io_buffer: &mut IoBuffer,
+    buffer_size: usize,
+    chained_bytes: Vec<Bytes>,
+    file: &File,
+    offset: usize,
+) -> Result<usize, Error> {
+    #[cfg(target_family = "unix")]
+    use std::os::unix::fs::FileExt;
+
+    #[cfg(target_family = "windows")]
+    use std::os::windows::fs::FileExt;
+
+    let mut next_offset = offset;
+    let mut written_len = 0;
+    let mut buffer_len = 0;
+
+    for bytes in chained_bytes {
+        let mut bytes_offset = 0;
+        while bytes_offset < bytes.len() {
+            let remaining_bytes = bytes.len() - bytes_offset;
+            let available_space = buffer_size - buffer_len;
+
+            let copy_length = remaining_bytes.min(available_space);
+            io_buffer[buffer_len..(buffer_len + copy_length)]
+                .copy_from_slice(&bytes[bytes_offset..bytes_offset + copy_length]);
+            buffer_len += copy_length;
+            bytes_offset += copy_length;
+
+            if buffer_len == buffer_size {
+                debug!(
+                    "Buffer filled with length: {}. next_offset: {}",
+                    buffer_len, next_offset
+                );
+                file.write_at(io_buffer, next_offset as u64)?;
+                next_offset += buffer_len;
+                written_len += buffer_len;
+                buffer_len = 0;
+            }
+        }
+    }
+
+    written_len += buffer_len;
+    if buffer_len > 0 {
+        // todo: align the min aligned slice into buffer
+        let up = align_up(ALIGN, buffer_len);
+        let slice = &io_buffer[..up];
+        file.write_at(slice, next_offset as u64)?;
+        debug!(
+            "Buffer partially filled with length: {}. next_offset: {}",
+            buffer_len, next_offset
+        );
+    }
+    Ok(written_len)
+}
+
+fn inner_direct_read(path: &str, offset: i64, len: i64) -> Result<Bytes, Error> {
     let left_boundary = align_down(ALIGN, offset as usize);
     let right_boundary = align_up(ALIGN, (offset + len) as usize);
     let range = right_boundary - left_boundary;
 
-    let mut buf = IoBuffer::with_capacity_in(range, &IO_BUFFER_ALLOCATOR);
-    unsafe {
-        buf.set_len(range);
-    }
+    let mut buf_from_pool = false;
+    let (mut buf, expected) = if range < IO_BUFFER_POOL.buffer_size() {
+        buf_from_pool = true;
+        (IO_BUFFER_POOL.acquire(), IO_BUFFER_POOL.buffer_size())
+    } else {
+        (IoBuffer::new(range), range)
+    };
+    // only gotten the min range buf to reduce io range access
+    let mut range_buf = &mut buf[..range];
 
     let path = Path::new(&path);
     let mut file = File::open(path)?;
@@ -76,13 +146,13 @@ pub fn inner_direct_read(path: &str, offset: i64, len: i64) -> Result<Bytes, Err
     #[cfg(target_family = "windows")]
     use std::os::windows::fs::FileExt;
 
-    let read = file.read_at(buf.as_mut(), left_boundary as u64)?;
-    if read != range {
+    let read = file.read_at(&mut range_buf[..], left_boundary as u64)?;
+    if !is_aligned(ALIGN, read) {
         return Err(io::Error::new(
             io::ErrorKind::Other,
             format!(
                 "Errors on direct read. expected: {}, actual: {}",
-                range, read
+                expected, read
             ),
         ));
     }
@@ -91,12 +161,15 @@ pub fn inner_direct_read(path: &str, offset: i64, len: i64) -> Result<Bytes, Err
     let end = start + len as usize;
     debug!(
         "read {} bytes. start:{}, end:{}. data: {:?}",
-        &buf.len(),
+        &range_buf.len(),
         start,
         end,
-        &buf.to_vec()
+        &range_buf.to_vec()
     );
-    let data = Bytes::copy_from_slice(&buf[start..end]);
+    let data = Bytes::copy_from_slice(&range_buf[start..end]);
+    if buf_from_pool {
+        IO_BUFFER_POOL.release(buf);
+    }
     Ok(data)
 }
 
@@ -259,19 +332,23 @@ impl LocalIO for SyncLocalIO {
                     }
                     Err(_) => 0,
                 };
-                let (next_offset, remain_bytes) = if file_len != written_bytes as u64 {
+                let (mut next_offset, remain_bytes) = if file_len != written_bytes as u64 {
                     let left = align_down(ALIGN, written_bytes);
+                    // todo: will only read 4k, but will use 16M io_buffer, it should be optimized
                     let remaining_bytes =
                         inner_direct_read(&raw_path, left as i64, (written_bytes - left) as i64)?;
                     (left as u64, Some(remaining_bytes))
                 } else {
                     (file_len, None)
                 };
-                let size = if let Some(b) = &remain_bytes {
-                    b.len()
-                } else {
-                    0
+                let mut batch_bytes = match raw_data {
+                    BytesWrapper::Direct(bytes) => vec![bytes],
+                    BytesWrapper::Composed(composed) => composed.to_vec(),
                 };
+                if let Some(remain_bytes) = remain_bytes {
+                    batch_bytes.insert(0, remain_bytes);
+                }
+                let total_len = batch_bytes.iter().map(|b| b.len()).sum::<usize>();
 
                 let mut opts = OpenOptions::new();
                 opts.create(true).write(true);
@@ -281,46 +358,25 @@ impl LocalIO for SyncLocalIO {
                     opts.custom_flags(libc::O_DIRECT);
                 }
                 let file = opts.open(path)?;
-                let batch_data = match raw_data {
-                    BytesWrapper::Direct(bytes) => bytes,
-                    BytesWrapper::Composed(composed) => composed.freeze(),
-                };
-                let flush_data = if let Some(remain_bytes) = remain_bytes {
-                    let mut bytes_mut =
-                        BytesMut::with_capacity(remain_bytes.len() + batch_data.len());
-                    bytes_mut.extend_from_slice(&remain_bytes);
-                    bytes_mut.extend_from_slice(&batch_data);
-                    bytes_mut.freeze()
-                } else {
-                    batch_data
-                };
-                debug!(
-                    "next_offset: {}. remain_bytes_len: {}. real flushed_data_len: {}",
-                    next_offset,
-                    size,
-                    flush_data.len()
-                );
-                let aligned_data = align_bytes(ALIGN, flush_data);
 
-                #[cfg(target_family = "unix")]
-                use std::os::unix::fs::FileExt;
-
-                #[cfg(target_family = "windows")]
-                use std::os::windows::fs::FileExt;
-
-                let written = file.write_at(&aligned_data, next_offset)?;
-                if written != aligned_data.len() {
+                let mut io_buffer = IO_BUFFER_POOL.acquire();
+                let written = fill_buffer_and_write(
+                    &mut io_buffer,
+                    IO_BUFFER_POOL.buffer_size(),
+                    batch_bytes,
+                    &file,
+                    next_offset as usize,
+                )?;
+                if written != total_len {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         format!(
                             "Errors on direct appending. expected: {}, actual: {}",
-                            aligned_data.len(),
-                            written
+                            total_len, written
                         ),
                     ));
                 }
                 file.sync_all()?;
-
                 Ok::<(), io::Error>(())
             })
             .instrument_await("wait the spawned block future")
@@ -351,12 +407,18 @@ impl LocalIO for SyncLocalIO {
 #[cfg(test)]
 mod test {
     use crate::bits::align_up;
+    use crate::composed_bytes::ComposedBytes;
     use crate::runtime::manager::create_runtime;
-    use crate::store::local::sync_io::{SyncLocalIO, ALIGN};
+    use crate::store::alignment::io_buffer_pool::IoBufferPool;
+    use crate::store::alignment::io_bytes::IoBuffer;
+    use crate::store::local::sync_io::{fill_buffer_and_write, SyncLocalIO, ALIGN};
     use crate::store::local::LocalIO;
     use bytes::{Bytes, BytesMut};
     use std::fs;
-    use std::thread::{sleep, Thread};
+    use std::fs::{File, OpenOptions};
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::path::Path;
+    use std::thread::sleep;
     use std::time::Duration;
 
     #[test]
@@ -442,6 +504,57 @@ mod test {
     }
 
     #[test]
+    fn test_write_pool_reuse() -> anyhow::Result<()> {
+        let mut buffer_pool = IoBufferPool::new(ALIGN, 1);
+        let mut io_buffer = buffer_pool.acquire();
+
+        let mut composed_bytes = ComposedBytes::new();
+        composed_bytes.put(Bytes::from(vec![b'a'; ALIGN]));
+        composed_bytes.put(Bytes::from(vec![b'b'; ALIGN]));
+
+        for compose in composed_bytes.iter() {
+            io_buffer[..].copy_from_slice(compose);
+            assert_eq!(ALIGN, io_buffer.len());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_direct_read_with_pool() -> anyhow::Result<()> {
+        let mut buffer_pool = IoBufferPool::new(ALIGN, 1);
+        let mut io_buffer = buffer_pool.acquire();
+
+        // write some data into the file.
+        let temp_dir = tempdir::TempDir::new("test_direct_read_with_pool")?;
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+        let data_file_name = format!("{}/{}", &temp_path, "1.data");
+
+        println!("created the temp file path: {}", &temp_path);
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&data_file_name)?;
+        file.write_all(&vec![b'x'; 100])?;
+        file.flush()?;
+        file.sync_all()?;
+
+        // read buffer from pool
+        let mut file = File::open(Path::new(&data_file_name))?;
+
+        #[cfg(target_family = "unix")]
+        use std::os::unix::fs::FileExt;
+
+        #[cfg(target_family = "windows")]
+        use std::os::windows::fs::FileExt;
+
+        let read = file.read_at(&mut io_buffer[..], 0)?;
+        assert_eq!(100, read);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_direct_io() -> anyhow::Result<()> {
         let base_runtime_ref = create_runtime(2, "base");
 
@@ -501,6 +614,54 @@ mod test {
                 .unwrap()
                 .len()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_recycle_io_buffer() -> anyhow::Result<()> {
+        for _ in 0..10 {
+            test_direct_io()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_fill_buffer_and_write() -> anyhow::Result<()> {
+        let temp_dir = tempdir::TempDir::new("test_fill_buffer_and_write")?;
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+        println!("created the temp file path: {}", &temp_path);
+        let file_path = format!("{}/{}", &temp_path, "1.data");
+        let mut opts = OpenOptions::new();
+        opts.create(true).write(true);
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.custom_flags(libc::O_DIRECT);
+        }
+        let file = opts.open(&file_path)?;
+
+        #[cfg(target_family = "unix")]
+        use std::os::unix::fs::FileExt;
+
+        #[cfg(target_family = "windows")]
+        use std::os::windows::fs::FileExt;
+
+        let mut io_buffer = IoBuffer::new(ALIGN);
+        let chained_bytes = vec![Bytes::from(vec![b'a'; 4095]), Bytes::from(vec![b'b'; 4098])];
+
+        let written_len = fill_buffer_and_write(&mut io_buffer, ALIGN, chained_bytes, &file, 0)?;
+        assert_eq!(4095 + 4098, written_len);
+        file.sync_all()?;
+        drop(file);
+
+        let mut buffer = vec![0; 4096];
+        let mut file = File::open(&file_path)?;
+        file.seek(SeekFrom::Start(0))?;
+        file.read(&mut buffer)?;
+
+        assert_eq!(vec![b'a'; 4095], buffer[0..4095]);
+        assert_eq!(vec![b'b'; 1], buffer[4095..]);
 
         Ok(())
     }

--- a/src/store/localfile.rs
+++ b/src/store/localfile.rs
@@ -255,8 +255,12 @@ impl LocalFileStore {
         }
 
         let shuffle_file_format = self.generate_shuffle_file_format(blocks, next_offset)?;
-        let aligned_next_offset = local_disk
-            .direct_append(&data_file_path, shuffle_file_format.data)
+        local_disk
+            .direct_append(
+                &data_file_path,
+                next_offset as usize,
+                shuffle_file_format.data,
+            )
             .instrument_await(format!(
                 "data flushing with {} bytes. path: {}",
                 shuffle_file_format.len, &data_file_path
@@ -276,7 +280,7 @@ impl LocalFileStore {
         locked_obj
             .deref()
             .pointer
-            .store(aligned_next_offset as i64, SeqCst);
+            .store(shuffle_file_format.offset, SeqCst);
 
         Ok(())
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod alignment;
 mod hadoop;
 #[cfg(feature = "hdfs")]
 pub mod hdfs;
@@ -23,7 +24,7 @@ pub mod local;
 pub mod localfile;
 pub mod mem;
 pub mod memory;
-mod spill;
+pub mod spill;
 
 use crate::app::{
     PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, RegisterAppContext,


### PR DESCRIPTION
Without directio, the performance is unstable when the page cache is flushing back to the disk under the tight system memory, which will make the rpc of getting memory latency high.

Actually, for the shuffle based storage, the flush disk blocks size is large like 128M, and for uniffle, it also will use the large memory to cache data to speed up. From this point, there is no need to use the system page cache. And so, this patch is to implement the direct io.

# DirecIO VS BufferIO

## getting localfile rpc latency

![image](https://github.com/user-attachments/assets/fdefa2ed-f028-45ec-85a1-29fc22a13971)
![image](https://github.com/user-attachments/assets/f46006ab-df4a-48fc-991a-5c807b31a761)


## sending data rpc latency

Due to the lower system load, the sending data latency on direct io will be more slower than the buffer io.

![image](https://github.com/user-attachments/assets/00597868-10a8-4c83-823d-7139b21ec3fd)
![image](https://github.com/user-attachments/assets/b7e4eea6-b450-4350-8520-1dc57d637b9c)


# Direct io performance comparation of buffer pool

![image](https://github.com/user-attachments/assets/53181a40-02ff-499b-88bd-64e5433d2fe4)

> for the direct io, we have to self manage the align buffer and disk block, if you don't use aligned buffer pool, the page fault will occur frequently, that will also make system load high. (this has be shown in the above screenshot)

About memory alignment and how to use direct io, I almost learn all from the great work of foyer. 
