### PR TITLE
feat: Add symbolize for memory profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,8 +2032,7 @@ dependencies = [
 [[package]]
 name = "jemalloc_pprof"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a883828bd6a4b957cd9f618886ff19e5f3ebd34e06ba0e855849e049fef32fb"
+source = "git+https://github.com/erikgrinaker/rust-jemalloc-pprof.git?branch=symbolize#0b146a1e2013bbc7fc8dc45f208f868c0b8ed193"
 dependencies = [
  "anyhow",
  "libc",
@@ -2204,8 +2203,7 @@ dependencies = [
 [[package]]
 name = "mappings"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9229c438fbf1c333926e2053c4c091feabbd40a1b590ec62710fea2384af9e"
+source = "git+https://github.com/erikgrinaker/rust-jemalloc-pprof.git?branch=symbolize#0b146a1e2013bbc7fc8dc45f208f868c0b8ed193"
 dependencies = [
  "anyhow",
  "libc",
@@ -2770,10 +2768,10 @@ dependencies = [
 [[package]]
 name = "pprof_util"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c568b3f8c1c37886ae07459b1946249e725c315306b03be5632f84c239f781"
+source = "git+https://github.com/erikgrinaker/rust-jemalloc-pprof.git?branch=symbolize#0b146a1e2013bbc7fc8dc45f208f868c0b8ed193"
 dependencies = [
  "anyhow",
+ "backtrace",
  "flate2",
  "num",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,8 +156,11 @@ version = "0.6.0"
 optional = true
 features = ["profiling", "unprefixed_malloc_on_supported_platforms"]
 
+# todo: When https://github.com/polarsignals/rust-jemalloc-pprof/pull/22 is merged, using the official repo
 [dependencies.jemalloc_pprof]
-version = "0.6.0"
+git = "https://github.com/erikgrinaker/rust-jemalloc-pprof.git"
+branch = "symbolize"
+features = ["symbolize"]
 optional = true
 
 [build-dependencies]


### PR DESCRIPTION
The pr of https://github.com/polarsignals/rust-jemalloc-pprof/pull/22 has been implemented the symbolize for jemalloc memory profile. So enable it in R1