### PR TITLE
feat(direct-io): Introduce config option to control read/append direct io whether to enable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -122,10 +122,21 @@ pub struct LocalfileStoreConfig {
 
     #[serde(default = "as_default_direct_io_enable")]
     pub direct_io_enable: bool,
+    #[serde(default = "as_default_direct_io_read_enable")]
+    pub direct_io_read_enable: bool,
+    #[serde(default = "as_default_direct_io_append_enable")]
+    pub direct_io_append_enable: bool,
 }
 
 fn as_default_direct_io_enable() -> bool {
     false
+}
+
+fn as_default_direct_io_read_enable() -> bool {
+    true
+}
+fn as_default_direct_io_append_enable() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,6 +179,8 @@ impl LocalfileStoreConfig {
             disk_healthy_check_interval_sec: as_default_disk_healthy_check_interval_sec(),
             io_scheduler_config: None,
             direct_io_enable: as_default_direct_io_enable(),
+            direct_io_read_enable: as_default_direct_io_read_enable(),
+            direct_io_append_enable: as_default_direct_io_append_enable(),
         }
     }
 }

--- a/src/store/localfile.rs
+++ b/src/store/localfile.rs
@@ -138,6 +138,8 @@ impl LocalFileStore {
             runtime_manager,
             partition_locks: Default::default(),
             direct_io_enable: localfile_config.direct_io_enable,
+            direct_io_read_enable: true,
+            direct_io_append_enable: true,
         }
     }
 


### PR DESCRIPTION
#19 is introduced for better performance that has been proved by the internal production spark jobs.
But from the point of reading, if using the buffer io, it may benifit from the huge machine free memory and that will not effert the io flushing performance.