### PR TITLE
feat: Sync all on buffer write to avoid latter page cache flush back storm

### DIFF
--- a/src/store/hybrid.rs
+++ b/src/store/hybrid.rs
@@ -654,7 +654,7 @@ pub(crate) mod tests {
     use bytes::{Buf, Bytes};
 
     use std::any::Any;
-    use std::collections::VecDeque;
+    use std::collections::{HashSet, VecDeque};
 
     use std::sync::atomic::Ordering::SeqCst;
     use std::sync::Arc;
@@ -794,9 +794,9 @@ pub(crate) mod tests {
             serialized_expected_task_ids_bitmap: Default::default(),
         }))?;
 
-        let mut accepted_block_ids = vec![];
+        let mut accepted_block_ids: HashSet<i64> = HashSet::new();
         for segment in response_data.from_memory().shuffle_data_block_segments {
-            accepted_block_ids.push(segment.block_id);
+            accepted_block_ids.insert(segment.block_id);
         }
 
         let local_index_data = runtime.wait(store.get_index(ReadingIndexViewContext {
@@ -820,11 +820,12 @@ pub(crate) mod tests {
                     let id = index_bytes.get_i64();
                     index_bytes.get_i64();
 
-                    accepted_block_ids.push(id);
+                    accepted_block_ids.insert(id);
                 }
             }
         }
 
+        let mut accepted_block_ids = accepted_block_ids.into_iter().collect::<Vec<i64>>();
         accepted_block_ids.sort();
         assert_eq!(accepted_block_ids, expected_block_ids);
 

--- a/src/store/hybrid.rs
+++ b/src/store/hybrid.rs
@@ -845,7 +845,7 @@ pub(crate) mod tests {
             partition_id: 0,
         };
         write_some_data(store.clone(), uid.clone(), data_len as i32, data, 400).await;
-        awaitility::at_most(Duration::from_secs(2))
+        awaitility::at_most(Duration::from_secs(10))
             .until(|| store.in_flight_bytes_size.load(SeqCst) == 0);
 
         // case1: all data has been flushed to localfile. the data in memory should be empty

--- a/src/store/local/sync_io.rs
+++ b/src/store/local/sync_io.rs
@@ -216,6 +216,10 @@ impl LocalIO for SyncLocalIO {
                     }
                 }
                 buf_writer.flush()?;
+
+                let file = buf_writer.into_inner()?;
+                file.sync_all()?;
+
                 Ok::<(), io::Error>(())
             })
             .instrument_await("wait the spawned block future")


### PR DESCRIPTION
# Background

When using the buffer io, I found the page cache flushing back will make disk IO utilization 100% and effect other read latency. But this will make me strange that if the data has been in the disk, the data from page cache eviction will not flush back into the disk.

How does this happen? Whether the data is not flushed into the disk when writing? I think yes! 

# Performance

After applying this into the online jobs, I found this is better than the previous performance, but it still slower than the mode of (direct write + buffer read). This may be caused by the lots of page cache missing.

The following pic is shown under the same IO pressure.

### With this patch
![image](https://github.com/user-attachments/assets/a392d3b7-4921-497f-b2eb-e6d1746b98de)

### Without this patch
![image](https://github.com/user-attachments/assets/9083612b-8c37-4f4d-85ee-fb69bea4e9fc)
