### PR TITLE
fix: Forget to register metric of `memory_spill_in_flight_bytes_of_huge_partition`

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -769,6 +769,11 @@ fn register_custom_metrics() {
         .register(Box::new(GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES.clone()))
         .expect("");
     REGISTRY
+        .register(Box::new(
+            GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES_OF_HUGE_PARTITION.clone(),
+        ))
+        .expect("");
+    REGISTRY
         .register(Box::new(TOTAL_MEMORY_SPILL_BYTES.clone()))
         .expect("");
     REGISTRY


### PR DESCRIPTION
We may introduce the macro to automic register metric when defining