### PR TITLE
fix: Potential incorrect partition lock deletion due to the shuffle level purge

### DIFF
--- a/src/store/localfile.rs
+++ b/src/store/localfile.rs
@@ -722,22 +722,7 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn purge_test() -> anyhow::Result<()> {
-        let temp_dir = tempdir::TempDir::new("test_local_store").unwrap();
-        let temp_path = temp_dir.path().to_str().unwrap().to_string();
-        println!("init local file path: {}", &temp_path);
-        let local_store = LocalFileStore::new(vec![temp_path.clone()]);
-
-        let runtime = local_store.runtime_manager.clone();
-
-        let app_id = "purge_test-app-id".to_string();
-        let uid = PartitionedUId {
-            app_id: app_id.clone(),
-            shuffle_id: 0,
-            partition_id: 0,
-        };
-
+    fn create_writing_ctx_by_uid(uid: &PartitionedUId) -> WritingViewContext {
         let data = b"hello world!hello china!";
         let size = data.len();
         let writing_ctx = WritingViewContext::create_for_test(
@@ -761,8 +746,37 @@ mod test {
                 },
             ],
         );
+        writing_ctx
+    }
 
-        let insert_result = runtime.wait(local_store.insert(writing_ctx));
+    #[test]
+    fn purge_test() -> anyhow::Result<()> {
+        let temp_dir = tempdir::TempDir::new("test_local_store").unwrap();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+        println!("init local file path: {}", &temp_path);
+        let local_store = LocalFileStore::new(vec![temp_path.clone()]);
+
+        let runtime = local_store.runtime_manager.clone();
+
+        let app_id = "purge_test-app-id".to_string();
+
+        let shuffle_id_1 = 1;
+        let shuffle_id_2 = 13;
+
+        let uid_1 = PartitionedUId {
+            app_id: app_id.clone(),
+            shuffle_id: shuffle_id_1,
+            partition_id: 0,
+        };
+        let uid_2 = PartitionedUId {
+            app_id: app_id.to_owned(),
+            shuffle_id: shuffle_id_2,
+            partition_id: 0,
+        };
+
+        // for shuffle_id = 1
+        let writing_ctx_1 = create_writing_ctx_by_uid(&uid_1);
+        let insert_result = runtime.wait(local_store.insert(writing_ctx_1));
         if insert_result.is_err() {
             println!("{:?}", insert_result.err());
             panic!()
@@ -771,23 +785,46 @@ mod test {
             true,
             runtime.wait(tokio::fs::try_exists(format!(
                 "{}/{}/{}/partition-{}.data",
-                &temp_path, &app_id, "0", "0"
+                &temp_path, &app_id, shuffle_id_1, "0"
+            )))?
+        );
+
+        // for shuffle_id = 13
+        let writing_ctx_2 = create_writing_ctx_by_uid(&uid_2);
+        let insert_result = runtime.wait(local_store.insert(writing_ctx_2));
+        if insert_result.is_err() {
+            println!("{:?}", insert_result.err());
+            panic!()
+        }
+        assert_eq!(
+            true,
+            runtime.wait(tokio::fs::try_exists(format!(
+                "{}/{}/{}/partition-{}.data",
+                &temp_path, &app_id, shuffle_id_2, "0"
             )))?
         );
 
         // shuffle level purge
         runtime
             .wait(local_store.purge(&PurgeDataContext::new(
-                &PurgeReason::SHUFFLE_LEVEL_EXPLICIT_UNREGISTER(app_id.to_owned(), 0),
+                &PurgeReason::SHUFFLE_LEVEL_EXPLICIT_UNREGISTER(app_id.to_owned(), shuffle_id_1),
             )))
             .expect("");
         assert_eq!(
             false,
             runtime.wait(tokio::fs::try_exists(format!(
                 "{}/{}/{}",
-                &temp_path, &app_id, 0
+                &temp_path, &app_id, shuffle_id_1
             )))?
         );
+        // the shuffle_id = 1 deletion will not effect shuffle_id = 13
+        let reading_ctx = ReadingIndexViewContext {
+            partition_id: uid_2.clone(),
+        };
+        let reading_result = runtime.wait(local_store.get_index(reading_ctx)).expect("");
+        if let ResponseDataIndex::Local(index) = reading_result {
+            assert!(index.data_file_len > 0);
+        }
 
         // app level purge
         runtime.wait(local_store.purge(&PurgeDataContext {

--- a/src/store/localfile.rs
+++ b/src/store/localfile.rs
@@ -188,7 +188,7 @@ impl LocalFileStore {
     }
 
     fn gen_relative_path_for_shuffle(app_id: &str, shuffle_id: i32) -> String {
-        format!("{}/{}", app_id, shuffle_id)
+        format!("{}/{}/", app_id, shuffle_id)
     }
 
     fn gen_relative_path_for_partition(uid: &PartitionedUId) -> (String, String) {


### PR DESCRIPTION
When deleting the shuffle level data (app_id = test_xx, shuffle_id = 1), riffle will construct the data prefix path: `test_xx/1 `to delete the partition lock map. But this will mis-delete the shuffle_id = 13's partiition lock due to missing `/`.

Incorrect logs as follows:

```
2025-03-10 10:11:01,202 ERROR executor.Executor: Exception in task 32.3 in stage 29.0 (TID 11715)
org.apache.uniffle.common.exception.RssException: Blocks read inconsistent: expected 6549 blocks, actual 19 blocks
	at org.apache.uniffle.common.util.RssUtils.checkProcessedBlockIds(RssUtils.java:393)
	at org.apache.uniffle.client.impl.ShuffleReadClientImpl.checkProcessedBlockIds(ShuffleReadClientImpl.java:326)
	at org.apache.spark.shuffle.reader.RssShuffleDataIterator.hasNext(RssShuffleDataIterator.java:132)
	at org.apache.spark.util.CompletionIterator.hasNext(CompletionIterator.scala:31)
	at org.apache.spark.shuffle.reader.RssShuffleReader$MultiPartitionIterator.hasNext(RssShuffleReader.java:324)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage2.sort_addToSorter_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage2.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.hasNext(WholeStageCodegenExec.scala:755)
	at org.apache.spark.sql.execution.GroupedIterator$.apply(GroupedIterator.scala:29)
	at org.apache.spark.sql.execution.MapGroupsExec.$anonfun$doExecute$16(objects.scala:394)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:898)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2$adapted(RDD.scala:898)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:497)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1470)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:500)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```