### PR TITLE
fix: Only mark as unhealthy when node app_running_num > 50

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -233,7 +233,9 @@ pub struct HealthServiceConfig {
     pub disk_used_ratio_health_threshold: Option<f64>,
     // the threshold of the memory allocated from allocator
     pub memory_allocated_threshold: Option<String>,
-    pub service_mem_used_without_change_time_window_sec: Option<usize>,
+
+    pub service_hang_of_mem_continuous_unchange_sec: Option<usize>,
+    pub service_hang_of_app_valid_number: Option<usize>,
 }
 
 // =========================================================

--- a/src/health_service.rs
+++ b/src/health_service.rs
@@ -20,7 +20,9 @@ pub struct HealthService {
     alive_app_number_limit: Option<usize>,
     disk_used_ratio_health_threshold: Option<f64>,
     memory_allocated_threshold: Option<u64>,
-    long_term_memory_used_size_without_change_threshold_seconds: Option<usize>,
+
+    service_hang_of_mem_continuous_unchange_sec: Option<usize>,
+    service_hang_of_app_valid_number: Option<usize>,
 
     health_stat: Arc<HealthStat>,
 }
@@ -86,8 +88,9 @@ impl HealthService {
             alive_app_number_limit: conf.alive_app_number_max_limit,
             disk_used_ratio_health_threshold: conf.disk_used_ratio_health_threshold,
             memory_allocated_threshold,
-            long_term_memory_used_size_without_change_threshold_seconds: conf
-                .service_mem_used_without_change_time_window_sec,
+            service_hang_of_mem_continuous_unchange_sec: conf
+                .service_hang_of_mem_continuous_unchange_sec,
+            service_hang_of_app_valid_number: conf.service_hang_of_app_valid_number,
             health_stat: Arc::new(Default::default()),
         }
     }
@@ -166,10 +169,13 @@ impl HealthService {
 
         // todo: ugly running_app_num threshold!
         // to solve potential decommission list being marked as unhealthy
-        if used == mem_stat.prev_val && used != 0 && running_app_num > 50 {
+        if used == mem_stat.prev_val
+            && used != 0
+            && running_app_num >= self.service_hang_of_app_valid_number.unwrap_or(50)
+        {
             if now - mem_stat.prev_timestamp
                 > self
-                    .long_term_memory_used_size_without_change_threshold_seconds
+                    .service_hang_of_mem_continuous_unchange_sec
                     .unwrap_or(5 * 60 * 1000) as u128
             {
                 mem_stat.is_marked_unhealthy = true;
@@ -199,7 +205,11 @@ mod tests {
         let mut config = mock_config();
         config
             .health_service_config
-            .service_mem_used_without_change_time_window_sec = Some(1);
+            .service_hang_of_mem_continuous_unchange_sec = Some(1);
+        // to bypass running app number check
+        config
+            .health_service_config
+            .service_hang_of_app_valid_number = Some(0);
         let config = config;
 
         let runtime_manager: RuntimeManager = Default::default();


### PR DESCRIPTION
To ignore decommissioning nodes into the unhealthy list.