### PR TITLE
feat: Throw root cause on hdfs operations failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "hdrs"
 version = "0.3.2"
-source = "git+https://github.com/zuston/hdrs?branch=extended#d96c74a1aca33eea197305ac4115fdf83bb8a703"
+source = "git+https://github.com/zuston/hdrs?rev=882ccbbdc4a4c6f850009b7973dc31faf346f87b#882ccbbdc4a4c6f850009b7973dc31faf346f87b"
 dependencies = [
  "errno",
  "hdfs-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ optional = true
 
 [dependencies.hdrs]
 git = "https://github.com/zuston/hdrs"
-branch = "extended"
+rev = "882ccbbdc4a4c6f850009b7973dc31faf346f87b"
 optional = true
 
 # jemalloc related optional dependencies


### PR DESCRIPTION
This PR is based on the https://github.com/zuston/hdrs/commit/882ccbbdc4a4c6f850009b7973dc31faf346f87b . To dig the hdfs writing failure, we need to get the detailed root cause rather than only one unknown 255 like the following screenshot.

![image](https://github.com/user-attachments/assets/c8456acb-f51e-4333-a711-787a8aa901bb)
