### PR TITLE
refactor(conf): Introduce on_change for callback

### DIFF
--- a/src/config_reconfigure.rs
+++ b/src/config_reconfigure.rs
@@ -187,10 +187,7 @@ mod tests {
         let conf_ref = DynamicConfRef {
             manager: reconf_manager.clone(),
             key: "grpc_port".to_owned(),
-            value: RwLock::new(0),
-            last_update_timestamp: AtomicU64::new(0),
-            refresh_interval: 1,
-            lock: Default::default(),
+            value: RwLock::new(19999),
         };
         let val = conf_ref.get();
         assert_eq!(19999, val);
@@ -199,12 +196,9 @@ mod tests {
             manager: reconf_manager,
             key: "memory_store.capacity".to_owned(),
             value: RwLock::new(ByteString {
-                val: "2M".to_string(),
-                parsed_val: 2 * 1000 * 1000,
+                val: "1M".to_string(),
+                parsed_val: 1 * 1000 * 1000,
             }),
-            last_update_timestamp: AtomicU64::new(0),
-            refresh_interval: 1,
-            lock: Default::default(),
         };
         let val = conf_ref.get();
         assert_eq!("1M", val.val);

--- a/src/config_reconfigure.rs
+++ b/src/config_reconfigure.rs
@@ -113,7 +113,7 @@ impl ReconfigurableConfManager {
         let val: T = serde_json::from_value(val)?;
 
         let c_ref: ConfigOption<T> = if self.reload_enabled {
-            Arc::new(DynamicConfRef::new(&self, key, val, 1))
+            Arc::new(DynamicConfRef::new(key, val))
         } else {
             Arc::new(StaticConfRef::new(val))
         };
@@ -187,7 +187,6 @@ mod tests {
         let config = Config::create_simple_config();
         let reconf_manager = ReconfigurableConfManager::new(&config, None)?;
         let conf_ref = DynamicConfRef {
-            manager: reconf_manager.clone(),
             key: "grpc_port".to_owned(),
             value: RwLock::new(19999),
         };
@@ -195,7 +194,6 @@ mod tests {
         assert_eq!(19999, val);
 
         let conf_ref: DynamicConfRef<ByteString> = DynamicConfRef {
-            manager: reconf_manager,
             key: "memory_store.capacity".to_owned(),
             value: RwLock::new(ByteString {
                 val: "1M".to_string(),

--- a/src/config_reconfigure.rs
+++ b/src/config_reconfigure.rs
@@ -1,5 +1,7 @@
 use crate::config::Config;
-use crate::config_ref::{ConfRef, ConfigOption, DynConfigOption, DynamicConfRef, StaticConfRef};
+use crate::config_ref::{
+    ConfRef, ConfigOption, ConfigOptionWrapper, DynamicConfRef, StaticConfRef,
+};
 use crate::runtime::{Runtime, RuntimeRef};
 use crate::util;
 use anyhow::{anyhow, Result};
@@ -53,7 +55,7 @@ fn flatten_json_value(
 pub struct ReconfigurableConfManager {
     pub conf_state: Arc<DashMap<String, Value>>,
     reload_enabled: bool,
-    attachments: Arc<DashMap<String, Arc<dyn DynConfigOption>>>,
+    attachments: Arc<DashMap<String, Arc<dyn ConfigOptionWrapper>>>,
 }
 
 pub struct ReloadOptions(String, u64, RuntimeRef);

--- a/src/config_ref.rs
+++ b/src/config_ref.rs
@@ -83,8 +83,6 @@ pub trait ConfRef<T: Clone + Send + Sync + 'static>: Send + Sync {
 }
 
 pub struct DynamicConfRef<T> {
-    // todo: remove this public modifier for better safety
-    pub manager: ReconfigurableConfManager,
     pub key: String,
     pub value: RwLock<T>,
 }
@@ -93,16 +91,10 @@ impl<T> DynamicConfRef<T>
 where
     T: DeserializeOwned + Clone,
 {
-    pub fn new(
-        manager: &ReconfigurableConfManager,
-        key: &str,
-        initial_value: T,
-        refresh_interval: u64,
-    ) -> Self {
+    pub fn new(key: &str, val: T) -> Self {
         Self {
-            manager: manager.clone(),
             key: key.to_string(),
-            value: RwLock::new(initial_value),
+            value: RwLock::new(val),
         }
     }
 }

--- a/src/config_ref.rs
+++ b/src/config_ref.rs
@@ -58,12 +58,12 @@ impl Into<u64> for ByteString {
 
 // Using a trait object for type erasure to make trait impls could be stored
 // into a container
-pub trait DynConfigOption: Send + Sync {
+pub trait ConfigOptionWrapper: Send + Sync {
     fn update(&self, value: &Value);
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
-impl<T> DynConfigOption for ConfigOption<T>
+impl<T> ConfigOptionWrapper for ConfigOption<T>
 where
     T: DeserializeOwned + Clone + Send + Sync + 'static,
 {


### PR DESCRIPTION
1. Using a trait object for type erasure to make trait impls could be stored into a container
2. For the callback injection for invoking side
3. Removing the ugly getting check logic for better performance