### PR TITLE
feat(event-bus): Dynamic concurrency limiter for event bus

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1195,7 +1195,7 @@ pub(crate) mod test {
         app_config.partition_split_threshold = "5B".to_string();
 
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref =
             AppManager::get_ref(runtime_manager.clone(), config, &storage, &reconf_manager).clone();
         app_manager_ref
@@ -1259,7 +1259,7 @@ pub(crate) mod test {
         app_config.partition_split_threshold = "20B".to_string();
 
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref =
             AppManager::get_ref(runtime_manager.clone(), config, &storage, &reconf_manager).clone();
         app_manager_ref
@@ -1309,7 +1309,7 @@ pub(crate) mod test {
         let config = create_config_for_partition_features();
 
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref =
             AppManager::get_ref(runtime_manager.clone(), config, &storage, &reconf_manager).clone();
         app_manager_ref
@@ -1346,7 +1346,7 @@ pub(crate) mod test {
         let runtime_manager: RuntimeManager = Default::default();
         let config = mock_config();
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref =
             AppManager::get_ref(runtime_manager.clone(), config, &storage, &reconf_manager).clone();
         app_manager_ref
@@ -1408,7 +1408,7 @@ pub(crate) mod test {
         let config = mock_config();
         let runtime_manager: RuntimeManager = Default::default();
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref =
             AppManager::get_ref(Default::default(), config, &storage, &reconf_manager).clone();
 
@@ -1427,7 +1427,7 @@ pub(crate) mod test {
         let runtime_manager: RuntimeManager = Default::default();
         let config = mock_config();
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref =
             AppManager::get_ref(runtime_manager.clone(), config, &storage, &reconf_manager).clone();
         app_manager_ref

--- a/src/config_reconfigure.rs
+++ b/src/config_reconfigure.rs
@@ -189,6 +189,7 @@ mod tests {
         let conf_ref = DynamicConfRef {
             key: "grpc_port".to_owned(),
             value: RwLock::new(19999),
+            callback: Default::default(),
         };
         let val = conf_ref.get();
         assert_eq!(19999, val);
@@ -199,6 +200,7 @@ mod tests {
                 val: "1M".to_string(),
                 parsed_val: 1 * 1000 * 1000,
             }),
+            callback: Default::default(),
         };
         let val = conf_ref.get();
         assert_eq!("1M", val.val);

--- a/src/config_ref.rs
+++ b/src/config_ref.rs
@@ -196,15 +196,12 @@ mod test {
         conf_ref.on_change(&serde_json::json!(100));
         assert_eq!(conf_ref.get(), 100);
 
-        let mut callback_called = false;
         conf_ref.with_callback(Box::new(|old, new| {
             assert_eq!(*old, 100);
             assert_eq!(*new, 200);
-            callback_called = true;
         }));
 
         conf_ref.on_change(&serde_json::json!(200));
-        assert!(callback_called);
 
         Ok(())
     }

--- a/src/config_ref.rs
+++ b/src/config_ref.rs
@@ -105,6 +105,15 @@ where
     }
 }
 
+impl<T> Into<ConfigOption<T>> for DynamicConfRef<T>
+where
+    T: Clone + Send + Sync + DeserializeOwned + 'static,
+{
+    fn into(self) -> ConfigOption<T> {
+        Arc::new(self)
+    }
+}
+
 impl<T> ConfRef<T> for DynamicConfRef<T>
 where
     T: DeserializeOwned + Clone + Send + Sync + 'static,

--- a/src/config_ref.rs
+++ b/src/config_ref.rs
@@ -1,11 +1,13 @@
 use crate::config_reconfigure::ReconfigurableConfManager;
 use crate::util;
 use bytesize::ByteSize;
+use once_cell::sync::OnceCell;
 use parking_lot::{Mutex, RwLock};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -35,7 +37,7 @@ impl Display for ByteString {
 }
 
 impl<'de> Deserialize<'de> for ByteString {
-    fn deserialize<D>(deserializer: D) -> anyhow::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -80,11 +82,14 @@ pub trait ConfRef<T: Clone + Send + Sync + 'static>: Send + Sync {
     type Output;
     fn get(&self) -> Self::Output;
     fn on_change(&self, value: &Value);
+    fn with_callback(&self, callback: Box<dyn Fn(&T, &T) + Send + Sync>);
 }
 
+/// DynamicConfRef: A dynamic configuration reference that supports runtime updates.
 pub struct DynamicConfRef<T> {
     pub key: String,
     pub value: RwLock<T>,
+    pub callback: OnceCell<Box<dyn Fn(&T, &T) + Send + Sync>>,
 }
 
 impl<T> DynamicConfRef<T>
@@ -95,6 +100,7 @@ where
         Self {
             key: key.to_string(),
             value: RwLock::new(val),
+            callback: Default::default(),
         }
     }
 }
@@ -113,26 +119,47 @@ where
     fn on_change(&self, val: &Value) {
         if let Ok(val) = serde_json::from_value::<T>(val.clone()) {
             let mut internal_val = self.value.write();
-            *internal_val = val;
+            let pre_val = &internal_val.deref().clone();
+            *internal_val = val.clone();
+            drop(internal_val); // Release the lock before invoking the callback
+
+            if let Some(callback) = self.callback.get() {
+                callback(pre_val, &val);
+            }
         }
+    }
+
+    fn with_callback(&self, callback: Box<dyn Fn(&T, &T) + Send + Sync>) {
+        self.callback.set(callback);
     }
 }
 
-// =======================================================
-
+/// StaticConfRef: A static configuration reference with a fixed value.
 pub struct StaticConfRef<T> {
     val: T,
 }
 
-impl<T> StaticConfRef<T> {
+impl<T> StaticConfRef<T>
+where
+    T: Clone + Send + Sync + DeserializeOwned + 'static,
+{
     pub fn new(val: T) -> Self {
         Self { val }
     }
 }
 
+impl<T> Into<ConfigOption<T>> for StaticConfRef<T>
+where
+    T: Clone + Send + Sync + DeserializeOwned + 'static,
+{
+    fn into(self) -> ConfigOption<T> {
+        Arc::new(self)
+    }
+}
+
 impl<T> ConfRef<T> for StaticConfRef<T>
 where
-    T: DeserializeOwned + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + DeserializeOwned + 'static,
 {
     type Output = T;
 
@@ -140,20 +167,45 @@ where
         self.val.clone()
     }
 
-    fn on_change(&self, value: &Value) {
-        // nothing to do
+    fn on_change(&self, _value: &Value) {
+        // No operation for StaticConfRef
+    }
+
+    fn with_callback(&self, _callback: Box<dyn Fn(&T, &T) + Send + Sync>) {
+        // No operation for StaticConfRef
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::config_ref::{ConfRef, StaticConfRef};
+    use super::*;
 
     #[test]
     fn test_fixed_conf_ref() -> anyhow::Result<()> {
         let const_val = 42;
         let conf_ref = StaticConfRef::new(const_val);
         assert_eq!(conf_ref.get(), const_val);
+        Ok(())
+    }
+
+    #[test]
+    fn test_dynamic_conf_ref() -> anyhow::Result<()> {
+        let mut conf_ref = DynamicConfRef::new("test_key", 42);
+        assert_eq!(conf_ref.get(), 42);
+
+        conf_ref.on_change(&serde_json::json!(100));
+        assert_eq!(conf_ref.get(), 100);
+
+        let mut callback_called = false;
+        conf_ref.with_callback(Box::new(|old, new| {
+            assert_eq!(*old, 100);
+            assert_eq!(*new, 200);
+            callback_called = true;
+        }));
+
+        conf_ref.on_change(&serde_json::json!(200));
+        assert!(callback_called);
+
         Ok(())
     }
 }

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -261,7 +261,7 @@ mod test {
 
     #[test]
     fn test_event_bus() -> anyhow::Result<()> {
-        let runtime = create_runtime(1, "test");
+        let runtime = create_runtime(4, "test");
         let mut event_bus = EventBus::new(
             &runtime,
             "test".to_string(),

--- a/src/health_service.rs
+++ b/src/health_service.rs
@@ -231,7 +231,7 @@ mod tests {
 
         let reconf_manager = ReconfigurableConfManager::new(&config, None)?;
         let runtime_manager: RuntimeManager = Default::default();
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref = AppManager::get_ref(
             Default::default(),
             config.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub async fn start_uniffle_worker(config: config::Config) -> Result<AppManagerRe
     let (tx, rx) = oneshot::channel::<()>();
 
     let reconf_manager = ReconfigurableConfManager::new(&config, None)?;
-    let storage = StorageService::init(&runtime_manager, &config);
+    let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
     let app_manager_ref = AppManager::get_ref(
         runtime_manager.clone(),
         config.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn main() -> Result<()> {
         Some((args.config.as_str(), 60, &runtime_manager.default_runtime).into()),
     )?;
 
-    let storage = StorageService::init(&runtime_manager, &config);
+    let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
     let app_manager_ref = AppManager::get_ref(
         runtime_manager.clone(),
         config.clone(),

--- a/src/server_state_manager.rs
+++ b/src/server_state_manager.rs
@@ -136,14 +136,10 @@ mod tests {
         let runtime_manager: RuntimeManager = Default::default();
         let config = mock_config();
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
-        let storage = StorageService::init(&runtime_manager, &config);
-        let app_manager_ref = AppManager::get_ref(
-            runtime_manager.clone(),
-            config.clone(),
-            &storage,
-            &reconf_manager,
-        )
-        .clone();
+
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
+        let app_manager_ref =
+            AppManager::get_ref(runtime_manager.clone(), config.clone(), &storage, &reconf_manager).clone();
 
         let server_state_manager = ServerStateManager::new(&app_manager_ref, &config);
 

--- a/src/server_state_manager.rs
+++ b/src/server_state_manager.rs
@@ -138,8 +138,13 @@ mod tests {
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
 
         let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
-        let app_manager_ref =
-            AppManager::get_ref(runtime_manager.clone(), config.clone(), &storage, &reconf_manager).clone();
+        let app_manager_ref = AppManager::get_ref(
+            runtime_manager.clone(),
+            config.clone(),
+            &storage,
+            &reconf_manager,
+        )
+        .clone();
 
         let server_state_manager = ServerStateManager::new(&app_manager_ref, &config);
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::config_reconfigure::ReconfigurableConfManager;
 use crate::runtime::manager::RuntimeManager;
 use crate::store::hybrid::HybridStore;
 use crate::store::{Store, StoreProvider};
@@ -9,8 +10,16 @@ pub type HybridStorage = Arc<HybridStore>;
 pub struct StorageService;
 
 impl StorageService {
-    pub fn init(runtime_manager: &RuntimeManager, config: &Config) -> HybridStorage {
-        let store = Arc::new(StoreProvider::get(runtime_manager.clone(), config.clone()));
+    pub fn init(
+        runtime_manager: &RuntimeManager,
+        config: &Config,
+        reconfig_manager: &ReconfigurableConfManager,
+    ) -> HybridStorage {
+        let store = Arc::new(StoreProvider::get(
+            runtime_manager.clone(),
+            config.clone(),
+            reconfig_manager,
+        ));
         store.clone().start();
         store.clone()
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -42,6 +42,7 @@ use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::composed_bytes::ComposedBytes;
+use crate::config_reconfigure::ReconfigurableConfManager;
 use crate::runtime::manager::RuntimeManager;
 use crate::store::index_codec::IndexCodec;
 use crate::store::spill::SpillWritingViewContext;
@@ -292,7 +293,11 @@ pub trait Persistent {}
 pub struct StoreProvider {}
 
 impl StoreProvider {
-    pub fn get(runtime_manager: RuntimeManager, config: Config) -> HybridStore {
-        HybridStore::from(config, runtime_manager)
+    pub fn get(
+        runtime_manager: RuntimeManager,
+        config: Config,
+        reconf_manager: &ReconfigurableConfManager,
+    ) -> HybridStore {
+        HybridStore::from(config, runtime_manager, reconf_manager)
     }
 }

--- a/src/store/spill/hierarchy_event_bus.rs
+++ b/src/store/spill/hierarchy_event_bus.rs
@@ -131,7 +131,7 @@ mod tests {
     use crate::config_reconfigure::ReconfigurableConfManager;
     use crate::event_bus::{Event, Subscriber};
     use crate::runtime::manager::RuntimeManager;
-    use crate::store::spill::hierarchy_event_bus::HierarchyEventBus;
+    use crate::store::spill::hierarchy_event_bus::{HierarchyEventBus, MAX_CONCURRENCY};
     use crate::store::spill::{SpillMessage, SpillWritingViewContext};
     use anyhow::Result;
     use async_trait::async_trait;
@@ -217,7 +217,7 @@ mod tests {
                 .max_blocking_threads_num(),
             hdfs_bus.concurrency_limit()
         );
-        assert_eq!(Semaphore::MAX_PERMITS, event_bus.parent.concurrency_limit());
+        assert_eq!(MAX_CONCURRENCY, event_bus.parent.concurrency_limit());
 
         // case2: set concurrency limit
         let mut config = Config::create_simple_config();
@@ -230,7 +230,7 @@ mod tests {
 
         assert_eq!(10, localfile_bus.concurrency_limit());
         assert_eq!(20, hdfs_bus.concurrency_limit());
-        assert_eq!(Semaphore::MAX_PERMITS, event_bus.parent.concurrency_limit());
+        assert_eq!(MAX_CONCURRENCY, event_bus.parent.concurrency_limit());
 
         Ok(())
     }

--- a/src/store/spill/hierarchy_event_bus.rs
+++ b/src/store/spill/hierarchy_event_bus.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use dashmap::DashMap;
 use tokio::sync::Semaphore;
 // This is the predefined event bus for the spill operations.
-// the parent is the dispatcher, it will firstly get the candidate
+// The parent is the dispatcher, it will firstly get the candidate
 // storage, and then send these concrete storage event into the corresponding
 // child storage specific eventbus.
 //

--- a/src/store/spill/hierarchy_event_bus.rs
+++ b/src/store/spill/hierarchy_event_bus.rs
@@ -44,6 +44,8 @@ use tokio::sync::Semaphore;
 //                                         |                              |
 //                                         +------------------------------+
 
+const MAX_CONCURRENCY: usize = 1000000;
+
 pub struct HierarchyEventBus<T> {
     parent: EventBus<T>,
     pub(crate) children: DashMap<StorageType, EventBus<T>>,
@@ -83,7 +85,7 @@ impl HierarchyEventBus<SpillMessage> {
         let parent: EventBus<SpillMessage> = EventBus::new(
             &runtime_manager.dispatch_runtime,
             "Hierarchy-Parent".to_string(),
-            StaticConfRef::new(usize::MAX).into(),
+            StaticConfRef::new(MAX_CONCURRENCY).into(),
         );
         let child_localfile: EventBus<SpillMessage> = EventBus::new(
             &runtime_manager.localfile_write_runtime,

--- a/src/urpc/server.rs
+++ b/src/urpc/server.rs
@@ -181,7 +181,7 @@ mod test {
 
         let reconf_manager = ReconfigurableConfManager::new(&config, None)?;
         let runtime_manager = RuntimeManager::from(config.clone().runtime_config.clone());
-        let storage = StorageService::init(&runtime_manager, &config);
+        let storage = StorageService::init(&runtime_manager, &config, &reconf_manager);
         let app_manager_ref = AppManager::get_ref(
             runtime_manager.clone(),
             config.clone(),


### PR DESCRIPTION
When the io layer of throttle is disabled, the IO concurrency is really important for the RPC latency and machine cpu load.

This PR is to make the concurrency limiter permits could be dynamically adjusted to responding to configuration changes