### PR TITLE
feat: Optional unhealthy status on initial starting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -386,6 +386,13 @@ pub struct Config {
 
     #[serde(default = "as_default_fallback_random_ports_enable")]
     pub fallback_random_ports_enable: bool,
+
+    #[serde(default = "as_default_initial_unhealthy_status_enable")]
+    pub initial_unhealthy_status_enable: bool,
+}
+
+fn as_default_initial_unhealthy_status_enable() -> bool {
+    false
 }
 
 fn as_default_fallback_random_ports_enable() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn start_uniffle_worker(config: config::Config) -> Result<AppManagerRe
 
     let app_manager_ref_cloned = app_manager_ref.clone();
     let rm_cloned = runtime_manager.clone();
-    let server_state_manager = ServerStateManager::new(&app_manager_ref);
+    let server_state_manager = ServerStateManager::new(&app_manager_ref, &config);
     runtime_manager.default_runtime.spawn(async move {
         DefaultRpcService {}.start(
             &config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn main() -> Result<()> {
     let health_service =
         HealthService::new(&app_manager_ref, &storage, &config.health_service_config);
 
-    let server_state_manager = ServerStateManager::new(&app_manager_ref);
+    let server_state_manager = ServerStateManager::new(&app_manager_ref, &config);
     let _ = SERVER_STATE_MANAGER_REF.set(server_state_manager.clone());
 
     MetricService::init(&config, runtime_manager.clone());

--- a/src/server_state_manager.rs
+++ b/src/server_state_manager.rs
@@ -138,8 +138,13 @@ mod tests {
         let config = mock_config();
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
         let storage = StorageService::init(&runtime_manager, &config);
-        let app_manager_ref =
-            AppManager::get_ref(runtime_manager.clone(), config.clone(), &storage, &reconf_manager).clone();
+        let app_manager_ref = AppManager::get_ref(
+            runtime_manager.clone(),
+            config.clone(),
+            &storage,
+            &reconf_manager,
+        )
+        .clone();
 
         let server_state_manager = ServerStateManager::new(&app_manager_ref, &config);
 

--- a/src/server_state_manager.rs
+++ b/src/server_state_manager.rs
@@ -2,7 +2,6 @@ use crate::app::AppManagerRef;
 use crate::config::Config;
 use crate::grpc::protobuf::uniffle::ServerStatus;
 use crate::util;
-use libc::{send, stat};
 use log::{info, warn};
 use once_cell::sync::OnceCell;
 use parking_lot::RwLock;

--- a/src/server_state_manager.rs
+++ b/src/server_state_manager.rs
@@ -139,7 +139,7 @@ mod tests {
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
         let storage = StorageService::init(&runtime_manager, &config);
         let app_manager_ref =
-            AppManager::get_ref(runtime_manager.clone(), config, &storage, &reconf_manager).clone();
+            AppManager::get_ref(runtime_manager.clone(), config.clone(), &storage, &reconf_manager).clone();
 
         let server_state_manager = ServerStateManager::new(&app_manager_ref, &config);
 

--- a/src/urpc/server.rs
+++ b/src/urpc/server.rs
@@ -193,7 +193,7 @@ mod test {
             &config,
             runtime_manager.clone(),
             app_manager_ref.clone(),
-            &ServerStateManager::new(&app_manager_ref),
+            &ServerStateManager::new(&app_manager_ref, &config),
         )?;
 
         Ok(())


### PR DESCRIPTION
## What

This PR provide the ability to make server status unhealthy on initial starting. 
And then we could use the riffle-ctl to make it active one by one.