### PR TITLE
feat: Introducing  `decommission_grpc_mode` in update status command of ctl

### DIFF
--- a/riffle-ctl/src/main.rs
+++ b/riffle-ctl/src/main.rs
@@ -97,6 +97,8 @@ enum Commands {
         instance: Option<String>,
         #[arg(short, long)]
         status: String,
+        #[arg(short, long)]
+        decommission_grpc_mode: bool,
     },
 }
 
@@ -174,7 +176,15 @@ fn main() -> anyhow::Result<()> {
             Box::new(QueryAction::new(sql, table_format, coordinator_http_url))
         }
 
-        Commands::Update { instance, status } => Box::new(NodeUpdateAction::new(instance, status)),
+        Commands::Update {
+            instance,
+            status,
+            decommission_grpc_mode,
+        } => Box::new(NodeUpdateAction::new(
+            instance,
+            status,
+            decommission_grpc_mode,
+        )),
 
         _ => panic!("Unknown command"),
     };


### PR DESCRIPTION
This PR is to be compatible with some legacy version riffle-servers