### PR TITLE
feat: Use flatten encoding for `send_shuffle_data` / `report_shuffle_result`

### DIFF
--- a/riffle-server/src/app_manager/partition_identifier.rs
+++ b/riffle-server/src/app_manager/partition_identifier.rs
@@ -1,11 +1,21 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Default, Debug, Hash, Clone)]
+#[derive(Ord, PartialOrd, Default, Debug, Hash, Clone)]
 pub struct PartitionedUId {
     pub app_id: String,
     pub shuffle_id: i32,
     pub partition_id: i32,
 }
+
+impl PartialEq for PartitionedUId {
+    fn eq(&self, other: &Self) -> bool {
+        self.partition_id == other.partition_id
+            && self.shuffle_id == other.shuffle_id
+            && self.app_id == other.app_id
+    }
+}
+
+impl Eq for PartitionedUId {}
 
 impl PartitionedUId {
     pub fn from(app_id: String, shuffle_id: i32, partition_id: i32) -> PartitionedUId {

--- a/riffle-server/src/grpc/protobuf/uniffle.proto
+++ b/riffle-server/src/grpc/protobuf/uniffle.proto
@@ -229,6 +229,20 @@ message SendShuffleDataRequest {
   repeated ShuffleData shuffleData = 4;
   int64 timestamp = 5;
   int32 stageAttemptNumber = 6;
+  CombinedShuffleData combinedShuffleData = 7;
+}
+
+message CombinedShuffleData {
+  repeated int32 partition_ids = 1;
+  repeated int32 partition_block_counts = 2;
+
+  repeated int64 block_ids = 3;
+  repeated int32 lengths = 4;
+  repeated int32 uncompress_lengths = 5;
+  repeated int64 crcs = 6;
+  repeated int64 task_attempt_ids = 7;
+
+  bytes combined_data = 8;
 }
 
 message SendShuffleDataResponse {

--- a/riffle-server/src/grpc/protobuf/uniffle.proto
+++ b/riffle-server/src/grpc/protobuf/uniffle.proto
@@ -126,7 +126,14 @@ message ReportShuffleResultRequest {
   int32 shuffleId = 2;
   int64 taskAttemptId = 3;
   int32 bitmapNum = 4;
+
+  // legacy layout
   repeated PartitionToBlockIds partitionToBlockIds = 5;
+
+  // new layout
+  repeated int32 partitionIds = 6;
+  repeated int64 blockIds = 7;
+  repeated int32 blockIdCounts = 8;
 }
 
 message PartitionToBlockIds {

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -436,12 +436,6 @@ impl ShuffleServer for DefaultShuffleServer {
                 continue;
             }
             let app_id_ref = app_id.clone();
-            let await_tree_msg = span!(
-                "Inserting data. appId: {:?}. shuffleId: {}. partitionId: {}",
-                &app_id_ref,
-                shuffle_id,
-                partition_id
-            );
             let uid = PartitionedUId {
                 app_id: app_id_ref,
                 shuffle_id,

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -28,14 +28,14 @@ use crate::grpc::protobuf::uniffle::shuffle_server_internal_server::ShuffleServe
 use crate::grpc::protobuf::uniffle::shuffle_server_server::ShuffleServer;
 use crate::grpc::protobuf::uniffle::{
     AppHeartBeatRequest, AppHeartBeatResponse, CancelDecommissionRequest,
-    CancelDecommissionResponse, DecommissionRequest, DecommissionResponse, FinishShuffleRequest,
-    FinishShuffleResponse, GetLocalShuffleDataRequest, GetLocalShuffleDataResponse,
-    GetLocalShuffleIndexRequest, GetLocalShuffleIndexResponse, GetMemoryShuffleDataRequest,
-    GetMemoryShuffleDataResponse, GetShuffleResultForMultiPartRequest,
+    CancelDecommissionResponse, CombinedShuffleData, DecommissionRequest, DecommissionResponse,
+    FinishShuffleRequest, FinishShuffleResponse, GetLocalShuffleDataRequest,
+    GetLocalShuffleDataResponse, GetLocalShuffleIndexRequest, GetLocalShuffleIndexResponse,
+    GetMemoryShuffleDataRequest, GetMemoryShuffleDataResponse, GetShuffleResultForMultiPartRequest,
     GetShuffleResultForMultiPartResponse, GetShuffleResultRequest, GetShuffleResultResponse,
     ReportShuffleResultRequest, ReportShuffleResultResponse, RequireBufferRequest,
     RequireBufferResponse, SendShuffleDataRequest, SendShuffleDataResponse, ShuffleCommitRequest,
-    ShuffleCommitResponse, ShuffleRegisterRequest, ShuffleRegisterResponse,
+    ShuffleCommitResponse, ShuffleData, ShuffleRegisterRequest, ShuffleRegisterResponse,
     ShuffleUnregisterByAppIdRequest, ShuffleUnregisterByAppIdResponse, ShuffleUnregisterRequest,
     ShuffleUnregisterResponse,
 };
@@ -49,7 +49,7 @@ use crate::metric::{
 };
 use crate::reject::RejectionPolicyGateway;
 use crate::server_state_manager::{ServerState, ServerStateManager};
-use crate::store::{PartitionedData, ResponseDataIndex};
+use crate::store::{Block, PartitionedData, ResponseDataIndex};
 use crate::util;
 use await_tree::{span, InstrumentAwait};
 use bytes::Bytes;
@@ -57,6 +57,7 @@ use croaring::{JvmLegacy, Treemap};
 use fastrace::future::FutureExt;
 use fastrace::trace;
 use log::{debug, error, info, warn};
+use std::arch::aarch64::veorq_s8;
 use std::collections::HashMap;
 use tokio::time::Instant;
 use tonic::{Request, Response, Status};
@@ -88,9 +89,87 @@ impl DefaultShuffleServer {
         }
     }
 
-    pub fn extract_block_ids(
-        req: ReportShuffleResultRequest,
-    ) -> anyhow::Result<HashMap<i32, Vec<i64>>> {
+    fn unpack_shuffle_data(req: SendShuffleDataRequest) -> anyhow::Result<Vec<PartitionedData>> {
+        match req.combined_shuffle_data {
+            None => Ok(req
+                .shuffle_data
+                .into_iter()
+                .map(PartitionedData::from)
+                .collect::<Vec<PartitionedData>>()),
+            Some(combined) => {
+                let CombinedShuffleData {
+                    partition_ids,
+                    partition_block_counts,
+                    block_ids,
+                    lengths,
+                    uncompress_lengths,
+                    crcs,
+                    task_attempt_ids,
+                    combined_data,
+                } = combined;
+
+                let total_blocks = block_ids.len();
+                if lengths.len() != total_blocks
+                    || uncompress_lengths.len() != total_blocks
+                    || crcs.len() != total_blocks
+                    || task_attempt_ids.len() != total_blocks
+                {
+                    anyhow::bail!("Inconsistent block-level lengths");
+                }
+
+                if partition_ids.len() != partition_block_counts.len() {
+                    anyhow::bail!("Mismatch between partition_ids and partition_block_counts");
+                }
+
+                let mut offset = 0;
+                let mut block_idx = 0;
+                let mut result = Vec::with_capacity(partition_ids.len());
+
+                for (i, &pid) in partition_ids.iter().enumerate() {
+                    let block_count = partition_block_counts[i] as usize;
+                    let mut blocks = Vec::with_capacity(block_count);
+
+                    for _ in 0..block_count {
+                        if block_idx >= total_blocks {
+                            anyhow::bail!("block index out of bounds");
+                        }
+
+                        let len = lengths[block_idx] as usize;
+                        let end = offset + len;
+                        if end > combined_data.len() {
+                            anyhow::bail!("combined_data out of bounds");
+                        }
+
+                        let block = Block {
+                            block_id: block_ids[block_idx],
+                            length: len as i32,
+                            uncompress_length: uncompress_lengths[block_idx],
+                            crc: crcs[block_idx],
+                            task_attempt_id: task_attempt_ids[block_idx],
+                            data: combined_data.slice(offset..end),
+                        };
+
+                        blocks.push(block);
+                        offset = end;
+                        block_idx += 1;
+                    }
+
+                    result.push(PartitionedData {
+                        partition_id: pid,
+                        blocks,
+                    });
+                }
+
+                if block_idx != total_blocks {
+                    anyhow::bail!("Not all blocks were consumed");
+                }
+
+                Ok(result)
+            }
+        }
+    }
+
+    fn unpack_block_ids(req: ReportShuffleResultRequest) -> anyhow::Result<HashMap<i32, Vec<i64>>> {
         let mut block_ids = HashMap::new();
 
         // for legacy layout
@@ -283,7 +362,7 @@ impl ShuffleServer for DefaultShuffleServer {
         let timer = GRPC_SEND_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
 
-        let app_id = req.app_id;
+        let app_id = &req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let ticket_id = req.require_buffer_id;
 
@@ -333,24 +412,27 @@ impl ShuffleServer for DefaultShuffleServer {
                 ret_msg: "No such buffer ticket id, it may be discarded due to timeout".to_string(),
             }));
         }
+        let app_id = app_id.to_string();
         let required_len_with_ticket = release_result.unwrap();
-
-        let mut blocks_map = HashMap::new();
-        for shuffle_data in req.shuffle_data {
-            let data: PartitionedData = shuffle_data.into();
-            let partition_id = data.partition_id;
-            let data_blocks = data.blocks;
-            let blocks = blocks_map.entry(partition_id).or_insert_with(|| vec![]);
-            blocks.extend(data_blocks);
-        }
+        let partition_blocks = match DefaultShuffleServer::unpack_shuffle_data(req) {
+            Ok(data) => data,
+            Err(e) => {
+                return Ok(Response::new(SendShuffleDataResponse {
+                    status: StatusCode::INTERNAL_ERROR.into(),
+                    ret_msg: e.to_string(),
+                }));
+            }
+        };
 
         let mut inserted_failure_occurs = false;
         let mut inserted_failure_error = None;
         let mut inserted_total_size = 0;
 
         let insert_start = util::now_timestamp_as_millis();
-        let mut shuffled_blocks: Vec<_> = blocks_map.into_iter().collect();
-        for (partition_id, blocks) in shuffled_blocks {
+        for partition_block in partition_blocks {
+            let partition_id = partition_block.partition_id;
+            let blocks = partition_block.blocks;
+
             if inserted_failure_occurs {
                 continue;
             }
@@ -682,7 +764,7 @@ impl ShuffleServer for DefaultShuffleServer {
             }));
         }
         let app = app.unwrap();
-        match DefaultShuffleServer::extract_block_ids(req) {
+        match DefaultShuffleServer::unpack_block_ids(req) {
             Ok(block_ids) => {
                 match app
                     .report_multi_block_ids(ReportMultiBlockIdsContext::new(shuffle_id, block_ids))
@@ -911,8 +993,13 @@ impl ShuffleServer for DefaultShuffleServer {
 
 #[cfg(test)]
 mod tests {
-    use crate::grpc::protobuf::uniffle::{PartitionToBlockIds, ReportShuffleResultRequest};
+    use crate::grpc::protobuf::uniffle::{
+        CombinedShuffleData, PartitionToBlockIds, ReportShuffleResultRequest,
+        SendShuffleDataRequest, ShuffleData,
+    };
     use crate::grpc::service::DefaultShuffleServer;
+    use crate::store::PartitionedData;
+    use bytes::Bytes;
 
     #[test]
     fn test_extract_block_ids_legacy() {
@@ -936,7 +1023,7 @@ mod tests {
             block_id_counts: vec![],
         };
 
-        let result = DefaultShuffleServer::extract_block_ids(req).unwrap();
+        let result = DefaultShuffleServer::unpack_block_ids(req).unwrap();
         assert_eq!(result.get(&1), Some(&vec![10, 11]));
         assert_eq!(result.get(&2), Some(&vec![20]));
     }
@@ -954,7 +1041,7 @@ mod tests {
             block_id_counts: vec![3, 1],
         };
 
-        let result = DefaultShuffleServer::extract_block_ids(req).unwrap();
+        let result = DefaultShuffleServer::unpack_block_ids(req).unwrap();
         assert_eq!(result.get(&1), Some(&vec![100, 101, 102]));
         assert_eq!(result.get(&2), Some(&vec![200]));
     }
@@ -972,7 +1059,84 @@ mod tests {
             block_id_counts: vec![3], // Too large
         };
 
-        let result = DefaultShuffleServer::extract_block_ids(req);
+        let result = DefaultShuffleServer::unpack_block_ids(req);
         assert!(result.is_err());
+    }
+
+    fn build_combined_data() -> SendShuffleDataRequest {
+        let combined_data = Bytes::from(vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+        SendShuffleDataRequest {
+            app_id: "app".into(),
+            shuffle_id: 1,
+            timestamp: 456,
+            stage_attempt_number: 1,
+            shuffle_data: vec![],
+            combined_shuffle_data: Some(CombinedShuffleData {
+                partition_ids: vec![1, 2],
+                partition_block_counts: vec![1, 1],
+                block_ids: vec![10, 20],
+                lengths: vec![3, 5],
+                uncompress_lengths: vec![3, 5],
+                crcs: vec![111, 222],
+                task_attempt_ids: vec![1000, 2000],
+                combined_data,
+            }),
+            require_buffer_id: 0,
+        }
+    }
+
+    #[test]
+    fn test_unpack_combined_shuffle_data_success() {
+        let req = build_combined_data();
+        let result = DefaultShuffleServer::unpack_shuffle_data(req).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].partition_id, 1);
+        assert_eq!(result[0].blocks.len(), 1);
+        assert_eq!(result[0].blocks[0].block_id, 10);
+        assert_eq!(result[0].blocks[0].data, Bytes::from(vec![1, 2, 3]));
+
+        assert_eq!(result[1].partition_id, 2);
+        assert_eq!(result[1].blocks.len(), 1);
+        assert_eq!(result[1].blocks[0].block_id, 20);
+        assert_eq!(result[1].blocks[0].data, Bytes::from(vec![4, 5, 6, 7, 8]));
+    }
+
+    #[test]
+    fn test_unpack_combined_shuffle_data_inconsistent_lengths() {
+        let mut req = build_combined_data();
+        if let Some(ref mut data) = req.combined_shuffle_data {
+            data.block_ids.pop(); // make block_ids shorter
+        }
+        let err = DefaultShuffleServer::unpack_shuffle_data(req).unwrap_err();
+        assert!(err.to_string().contains("Inconsistent block-level lengths"));
+    }
+
+    #[test]
+    fn test_unpack_legacy_shuffle_data() {
+        let legacy = SendShuffleDataRequest {
+            app_id: "app".into(),
+            shuffle_id: 1,
+            timestamp: 456,
+            stage_attempt_number: 1,
+            combined_shuffle_data: None,
+            shuffle_data: vec![
+                ShuffleData {
+                    partition_id: 1,
+                    block: vec![],
+                },
+                ShuffleData {
+                    partition_id: 2,
+                    block: vec![],
+                },
+            ],
+            require_buffer_id: 0,
+        };
+
+        let result = DefaultShuffleServer::unpack_shuffle_data(legacy).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].partition_id, 1);
+        assert_eq!(result[1].partition_id, 2);
     }
 }

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -45,7 +45,8 @@ use crate::metric::{
     GRPC_GET_LOCALFILE_DATA_PROCESS_TIME, GRPC_GET_LOCALFILE_DATA_TRANSPORT_TIME,
     GRPC_GET_LOCALFILE_INDEX_LATENCY, GRPC_GET_MEMORY_DATA_FREEZE_PROCESS_TIME,
     GRPC_GET_MEMORY_DATA_PROCESS_TIME, GRPC_GET_MEMORY_DATA_TRANSPORT_TIME,
-    GRPC_SEND_DATA_PROCESS_TIME, GRPC_SEND_DATA_TRANSPORT_TIME,
+    GRPC_SEND_DATA_PROCESS_TIME, GRPC_SEND_DATA_TRANSPORT_TIME, RPC_BATCH_BYTES_OPERATION,
+    RPC_BATCH_DATA_BYTES_HISTOGRAM, TOTAL_MEMORY_USED,
 };
 use crate::reject::RejectionPolicyGateway;
 use crate::server_state_manager::{ServerState, ServerStateManager};
@@ -482,6 +483,12 @@ impl ShuffleServer for DefaultShuffleServer {
                 ret_msg: inserted_failure_error.unwrap(),
             }));
         }
+
+        TOTAL_MEMORY_USED.inc_by(inserted_total_size as u64);
+
+        RPC_BATCH_DATA_BYTES_HISTOGRAM
+            .with_label_values(&[&RPC_BATCH_BYTES_OPERATION::SEND_DATA.to_string()])
+            .observe(inserted_total_size as f64);
 
         timer.observe_duration();
         Ok(Response::new(SendShuffleDataResponse {

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -57,7 +57,6 @@ use croaring::{JvmLegacy, Treemap};
 use fastrace::future::FutureExt;
 use fastrace::trace;
 use log::{debug, error, info, warn};
-use std::arch::aarch64::veorq_s8;
 use std::collections::HashMap;
 use tokio::time::Instant;
 use tonic::{Request, Response, Status};

--- a/riffle-server/src/lib.rs
+++ b/riffle-server/src/lib.rs
@@ -209,6 +209,9 @@ pub async fn write_read_for_one_time(mut client: ShuffleServerClient<Channel>) -
                     partition_id: idx,
                     block_ids: vec![block_id],
                 }],
+                partition_ids: vec![],
+                block_ids: vec![],
+                block_id_counts: vec![],
             })
             .await?;
     }

--- a/riffle-server/src/lib.rs
+++ b/riffle-server/src/lib.rs
@@ -190,6 +190,7 @@ pub async fn write_read_for_one_time(mut client: ShuffleServerClient<Channel>) -
                 }],
                 timestamp: 0,
                 stage_attempt_number: 0,
+                combined_shuffle_data: None,
             })
             .await?;
 

--- a/riffle-server/src/store/hybrid.rs
+++ b/riffle-server/src/store/hybrid.rs
@@ -614,39 +614,37 @@ impl Store for HybridStore {
 
     async fn insert(&self, ctx: WritingViewContext) -> Result<(), WorkerError> {
         let store = self.hot_store.clone();
-        let uid = ctx.uid.clone();
+        let uid = &ctx.uid;
+
+        if !self.is_memory_only() {
+            // for single buffer spill
+            //
+            // maybe the same partition will trigger spill at the same time, the thread
+            // safe will be ensured by the buffer self.
+            // if the first request has been handled, the following requests will not
+            // fast skip this logic.
+            if let Some(threshold) = self.memory_spill_partition_max_threshold {
+                let size = self.hot_store.get_buffer_staging_size(&uid)?;
+                if size > threshold {
+                    if let Err(err) = self.single_buffer_spill(&uid).await {
+                        warn!(
+                            "Errors on single buffer spill. uid: {:?}. err: {:?}",
+                            &uid, err
+                        );
+                    }
+                }
+            }
+
+            if !self.async_watermark_spill_enable {
+                if let Ok(_) = self.sync_memory_spill_lock.try_lock() {
+                    if let Err(err) = self.watermark_spill().await {
+                        warn!("Errors on watermark spill. {:?}", err)
+                    }
+                }
+            }
+        }
+
         let insert_result = store.insert(ctx).await;
-
-        if self.is_memory_only() {
-            return insert_result;
-        }
-
-        // for single buffer spill
-        //
-        // maybe the same partition will trigger spill at the same time, the thread
-        // safe will be ensured by the buffer self.
-        // if the first request has been handled, the following requests will not
-        // fast skip this logic.
-        if let Some(threshold) = self.memory_spill_partition_max_threshold {
-            let size = self.hot_store.get_buffer_staging_size(&uid)?;
-            if size > threshold {
-                if let Err(err) = self.single_buffer_spill(&uid).await {
-                    warn!(
-                        "Errors on single buffer spill. uid: {:?}. err: {:?}",
-                        &uid, err
-                    );
-                }
-            }
-        }
-
-        if !self.async_watermark_spill_enable {
-            if let Ok(_) = self.sync_memory_spill_lock.try_lock() {
-                if let Err(err) = self.watermark_spill().await {
-                    warn!("Errors on watermark spill. {:?}", err)
-                }
-            }
-        }
-
         insert_result
     }
 

--- a/riffle-server/src/store/memory.rs
+++ b/riffle-server/src/store/memory.rs
@@ -258,12 +258,6 @@ impl Store for MemoryStore {
         let buffer = self.get_or_create_buffer(uid);
         buffer.append(blocks, ctx.data_size)?;
 
-        TOTAL_MEMORY_USED.inc_by(size);
-
-        RPC_BATCH_DATA_BYTES_HISTOGRAM
-            .with_label_values(&[&RPC_BATCH_BYTES_OPERATION::SEND_DATA.to_string()])
-            .observe(size as f64);
-
         Ok(())
     }
 


### PR DESCRIPTION
Too many repeated definition will slow down the grpc decoding performance. And so, this PR is to use the flatten encoding for `send_shuffle_data` and `report_shuffle_result`. But this also should be supported by the uniffle client side.

Anyway, current patch has been compatible with the legacy encoding mode.

BTW, this PR also optimizes the partial above `send_shuffle_data` rpc hot point performance
1. Try to speed up the hash comparison with the `PartitionedUID`
2. Remove the frequent and loop metrics calculation