### PR TITLE
feat: Remove app level statistics with metrics format

### DIFF
--- a/riffle-server/src/event_bus.rs
+++ b/riffle-server/src/event_bus.rs
@@ -195,10 +195,7 @@ impl<T: Send + Sync + Clone + 'static> EventBus<T> {
 mod test {
     use crate::config_ref::{ConfRef, ConfigOption, DynamicConfRef, StaticConfRef};
     use crate::event_bus::{Event, EventBus, Subscriber};
-    use crate::metric::{
-        TOTAL_APP_FLUSHED_BYTES, TOTAL_EVENT_BUS_EVENT_HANDLED_SIZE,
-        TOTAL_EVENT_BUS_EVENT_PUBLISHED_SIZE,
-    };
+    use crate::metric::{TOTAL_EVENT_BUS_EVENT_HANDLED_SIZE, TOTAL_EVENT_BUS_EVENT_PUBLISHED_SIZE};
     use crate::runtime::manager::create_runtime;
     use async_trait::async_trait;
     use std::sync::atomic::Ordering::{Relaxed, SeqCst};

--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -594,24 +594,6 @@ pub static GAUGE_RUNTIME_IDLE_THREAD_NUM: Lazy<IntGaugeVec> = Lazy::new(|| {
 pub static RESIDENT_BYTES: Lazy<IntGauge> =
     Lazy::new(|| IntGauge::new("resident_bytes", "resident_bytes").unwrap());
 
-pub static GAUGE_TOPN_APP_RESIDENT_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        "topN_app_resident_bytes",
-        "topN app resident bytes",
-        &["app_id"]
-    )
-    .unwrap()
-});
-
-pub static TOTAL_APP_FLUSHED_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "app_flushed_bytes",
-        "total app used bytes in persistent storage",
-        &["app_id", "storage_type"]
-    )
-    .unwrap()
-});
-
 pub static RPC_BATCH_DATA_BYTES_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
     let opts = histogram_opts!(
         "rpc_batch_data_bytes_histogram",
@@ -896,14 +878,6 @@ fn register_custom_metrics() {
         .register(Box::new(
             TOTAL_SPILL_EVENTS_DROPPED_WITH_APP_NOT_FOUND.clone(),
         ))
-        .expect("");
-
-    REGISTRY
-        .register(Box::new(GAUGE_TOPN_APP_RESIDENT_BYTES.clone()))
-        .expect("");
-
-    REGISTRY
-        .register(Box::new(TOTAL_APP_FLUSHED_BYTES.clone()))
         .expect("");
 
     REGISTRY

--- a/riffle-server/src/store/spill/metrics.rs
+++ b/riffle-server/src/store/spill/metrics.rs
@@ -2,8 +2,7 @@ use crate::app_manager::application_identifier::ApplicationId;
 use crate::config::StorageType;
 use crate::metric::{
     GAUGE_MEMORY_SPILL_IN_FLUSHING_BYTES, GAUGE_MEMORY_SPILL_IN_FLUSHING_OPERATION,
-    MEMORY_SPILL_IN_FLUSHING_BYTES_HISTOGRAM, TOTAL_APP_FLUSHED_BYTES,
-    TOTAL_MEMORY_SPILL_IN_FLUSHING_OPERATION,
+    MEMORY_SPILL_IN_FLUSHING_BYTES_HISTOGRAM, TOTAL_MEMORY_SPILL_IN_FLUSHING_OPERATION,
 };
 
 const ALL_STORAGE_TYPE: &str = "ALL";
@@ -43,11 +42,6 @@ impl FlushingMetricsMonitor {
             MEMORY_SPILL_IN_FLUSHING_BYTES_HISTOGRAM
                 .with_label_values(&[&stype])
                 .observe(size as f64);
-
-            let raw_app_id = app_id.to_string();
-            TOTAL_APP_FLUSHED_BYTES
-                .with_label_values(&[raw_app_id.as_str(), &stype])
-                .inc_by(size as u64);
         }
 
         Self {


### PR DESCRIPTION
With app_id label in metrics, this will hurt the prometheus performance. And the purge is hard and unprecise.