### PR TITLE
feat: Add fallback to prevent panics on application ID parsing errors

### DIFF
--- a/riffle-server/src/app_manager/application_identifier.rs
+++ b/riffle-server/src/app_manager/application_identifier.rs
@@ -1,51 +1,70 @@
+use anyhow::{anyhow, Result};
 use clap::builder::Str;
+use log::warn;
 use std::fmt::{Display, Formatter};
 
-const APP_PREFIX: &str = "application_";
-const SPLIT_PREFIX: &str = "_";
+/// Optimized for faster hash-based lookups when using the app ID as a map key.
+/// Also includes a fallback strategy to support other Spark application ID formats for compatibility.
+const YARN_APP_PREFIX: &str = "application_";
+const YARN_SPLIT_PREFIX: &str = "_";
 
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Default, Hash)]
-pub struct ApplicationId {
-    part_1: u64,
-    part_2: u32,
-    part_3: u64,
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
+pub enum ApplicationId {
+    YARN(u64, u32, u64),
+    OTHERS(String),
+}
+
+impl Default for ApplicationId {
+    fn default() -> Self {
+        ApplicationId::YARN(1, 2, 2)
+    }
 }
 
 impl ApplicationId {
     pub fn from(raw_app_id: &str) -> Self {
-        let parts: Vec<&str> = raw_app_id
-            .strip_prefix(APP_PREFIX)
-            .unwrap_or(raw_app_id)
-            .split(SPLIT_PREFIX)
-            .collect();
-
-        if parts.len() != 3 {
-            panic!("Invalid application id format: {}", raw_app_id);
-        }
-
-        ApplicationId {
-            part_1: parts[0].parse().unwrap_or(0),
-            part_2: parts[1].parse().unwrap_or(0),
-            part_3: parts[2].parse().unwrap_or(0),
-        }
+        Self::init(raw_app_id).unwrap()
     }
 
     pub fn mock() -> Self {
-        Self {
-            part_1: 1,
-            part_2: 2,
-            part_3: 3,
-        }
+        ApplicationId::default()
+    }
+
+    // When app registering in the first time, the app id should be checked.
+    pub fn init(raw_app_id: &str) -> Result<ApplicationId> {
+        let id = match raw_app_id.strip_prefix(YARN_APP_PREFIX) {
+            None => ApplicationId::OTHERS(raw_app_id.to_string()),
+            Some(app_id) => {
+                let parts: Vec<&str> = app_id.split(YARN_SPLIT_PREFIX).collect();
+                if parts.len() != 3 {
+                    warn!("Illegal app id: {} but fallback!", raw_app_id);
+                    ApplicationId::OTHERS(raw_app_id.to_string())
+                } else {
+                    ApplicationId::YARN(
+                        parts[0].parse().unwrap_or(0),
+                        parts[1].parse().unwrap_or(0),
+                        parts[2].parse().unwrap_or(0),
+                    )
+                }
+            }
+        };
+        Ok(id)
     }
 }
 
 impl Display for ApplicationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{APP_PREFIX}{}{SPLIT_PREFIX}{}{SPLIT_PREFIX}{}",
-            self.part_1, self.part_2, self.part_3
-        )
+        match &self {
+            ApplicationId::YARN(p1, p2, p3) => {
+                write!(
+                    f,
+                    "{YARN_APP_PREFIX}{}{YARN_SPLIT_PREFIX}{}{YARN_SPLIT_PREFIX}{}",
+                    p1, p2, p3
+                )
+            }
+            ApplicationId::OTHERS(raw) => {
+                write!(f, "{raw}")
+            }
+        }
     }
 }
 
@@ -66,18 +85,21 @@ mod tests {
     #[test]
     fn test_application_id_parsing() {
         let app_id = ApplicationId::from("application_1747379850000_7237726_1749434628480");
-        assert_eq!(app_id.part_1, 1747379850000);
-        assert_eq!(app_id.part_2, 7237726);
-        assert_eq!(app_id.part_3, 1749434628480);
+        match app_id {
+            ApplicationId::YARN(p1, p2, p3) => {
+                assert_eq!(p1, 1747379850000);
+                assert_eq!(p2, 7237726);
+                assert_eq!(p3, 1749434628480);
+            }
+            ApplicationId::OTHERS(_) => {
+                panic!()
+            }
+        }
     }
 
     #[test]
     fn test_application_id_display() {
-        let app_id = ApplicationId {
-            part_1: 1747379850000,
-            part_2: 7237726,
-            part_3: 1749434628480,
-        };
+        let app_id = ApplicationId::YARN(1747379850000, 7237726, 1749434628480);
         assert_eq!(
             app_id.to_string(),
             "application_1747379850000_7237726_1749434628480"
@@ -85,8 +107,23 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid application id format")]
-    fn test_invalid_format() {
-        ApplicationId::from("invalid_format");
+    fn test_local_app_id() {
+        let raw = "local-456_23234";
+        let id = ApplicationId::from(raw);
+        assert_eq!(id.to_string(), raw);
+    }
+
+    #[test]
+    fn test_illegal_yarn_app_id() {
+        let raw = "application_2323_2";
+        let id = ApplicationId::from(raw);
+        assert_eq!(id.to_string(), raw);
+    }
+
+    #[test]
+    fn test_unknown_app_id_should_pass() {
+        let raw = "spark-my-app-0ffbc216fc3b4f4f8f0a437e8f93e087";
+        let id = ApplicationId::from(raw);
+        assert_eq!(id.to_string(), raw);
     }
 }


### PR DESCRIPTION
To speed up hash lookups for YARN application IDs, we parse and split the ID into usize components for performance. However, different Spark submission modes produce different application ID formats. For example, a local Spark submission using Riffle may trigger a panic on the server side due to unexpected ID formats—this is unacceptable.

This PR introduces a fallback mechanism to gracefully handle such parsing failures and avoid panics.

Known application ID formats include:
	1.	Local submission: local-xxx_xxxx
	2.	Standalone submission: app-<timestamp>-<driver id>
	3.	…