### PR TITLE
feat(1/N): Add support of read ahead

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,14 +85,6 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Cache target-docker
-        uses: actions/cache@v3
-        with:
-          path: target-docker
-          key: target-docker-${{ runner.os }}-${{ matrix.name }}
-          restore-keys: |
-            target-docker-${{ runner.os }}-${{ matrix.name }}-
-
       - name: Build
         run: ${{ matrix.build_command }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "hdrs"
 version = "0.3.2"
-source = "git+https://github.com/zuston/hdrs?rev=24bc9949a24e14808440614a47d37e86756f515f#24bc9949a24e14808440614a47d37e86756f515f"
+source = "git+https://github.com/zuston/hdrs?rev=e1f7167adc61198b82bf0fa70b17f4565f1d3a21#e1f7167adc61198b82bf0fa70b17f4565f1d3a21"
 dependencies = [
  "errno",
  "hdfs-sys",

--- a/riffle-ctl/src/actions/disk_append_bench.rs
+++ b/riffle-ctl/src/actions/disk_append_bench.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 use bytesize;
 use clap::builder::Str;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use log::info;
 use riffle_server::config::{Config, IoLimiterConfig, RuntimeConfig};
 use riffle_server::http::HttpMonitorService;
 use riffle_server::runtime::manager::{create_runtime, RuntimeManager};
@@ -47,7 +48,7 @@ impl DiskAppendBenchAction {
         let mut config = Config::create_simple_config();
         let port = util::find_available_port().unwrap();
         config.http_port = port;
-        println!("Expose http service with port: {}", port);
+        info!("Expose http service with port: {}", port);
 
         let runtime_manager = RuntimeManager::from(RuntimeConfig {
             read_thread_num: 512,
@@ -118,7 +119,7 @@ impl Action for DiskAppendBenchAction {
         let write_size = self.write_size as usize;
 
         let total_bytes = (self.concurrency * batch_number * write_size) as u64;
-        println!(
+        info!(
             "Total data to write: {}",
             bytesize::to_string(total_bytes, true)
         );

--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -14,7 +14,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub struct DiskReadBenchAction {
     dir: String,
@@ -120,6 +120,7 @@ impl Action for DiskReadBenchAction {
                     let batch_elapsed = batch_start.elapsed();
                     latencies.push(batch_elapsed.as_secs_f64());
                     offset += read_size as u64;
+                    tokio::time::sleep(Duration::from_millis(20)).await;
                 }
                 let elapsed = start.elapsed();
                 latencies.sort_by(|a, b| a.partial_cmp(b).unwrap());

--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -15,7 +15,6 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 pub struct DiskReadBenchAction {

--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -120,7 +120,7 @@ impl Action for DiskReadBenchAction {
             let pb = multi_pb.add(ProgressBar::new(batch_number));
             pb.set_style(
                 ProgressStyle::default_bar()
-                    .template(&format!("{{prefix}} [{elapsed_precise}] {{bar:40.cyan/blue}} {{pos:>3}}/{{len:3}} | {{msg}}"))
+                    .template("[{prefix}] [{elapsed_precise}] {bar:40.cyan/blue} {pos:>3}/{len:3} | {msg}")
                     .unwrap()
                     .progress_chars("##-"),
             );

--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -95,9 +95,8 @@ impl Action for DiskReadBenchAction {
             .collect();
 
         if files.is_empty() || files.len() < self.concurrency {
-            println!("Creating read_bench files to read...");
+            info!("Creating read_bench {} files to read...", self.concurrency);
             self.append_action.act().await?;
-            println!("Done!");
         }
 
         let mut futures = vec![];

--- a/riffle-ctl/src/main.rs
+++ b/riffle-ctl/src/main.rs
@@ -49,6 +49,8 @@ enum Commands {
         concurrency: usize,
         #[arg(short, long)]
         read_ahead_enable: bool,
+        #[arg(short, long)]
+        sleep_millis_per_batch: usize,
     },
     #[command(about = "Using the riffle IO scheduler to test local disk IO")]
     DiskAppendBench {
@@ -150,12 +152,14 @@ fn main() -> anyhow::Result<()> {
             batch_number,
             concurrency,
             read_ahead_enable,
+            sleep_millis_per_batch,
         } => Box::new(DiskReadBenchAction::new(
             dir,
             read_size,
             batch_number,
             concurrency,
             read_ahead_enable,
+            sleep_millis_per_batch,
         )),
         Commands::DiskAppendBench {
             dir,

--- a/riffle-ctl/src/main.rs
+++ b/riffle-ctl/src/main.rs
@@ -47,6 +47,8 @@ enum Commands {
         batch_number: usize,
         #[arg(short, long)]
         concurrency: usize,
+        #[arg(short, long)]
+        read_ahead_enable: bool,
     },
     #[command(about = "Using the riffle IO scheduler to test local disk IO")]
     DiskAppendBench {
@@ -147,11 +149,13 @@ fn main() -> anyhow::Result<()> {
             read_size,
             batch_number,
             concurrency,
+            read_ahead_enable,
         } => Box::new(DiskReadBenchAction::new(
             dir,
             read_size,
             batch_number,
             concurrency,
+            read_ahead_enable,
         )),
         Commands::DiskAppendBench {
             dir,

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -134,6 +134,19 @@ pub struct LocalfileStoreConfig {
     // This is only for urpc
     #[serde(default = "as_default_read_io_sendfile_enable")]
     pub read_io_sendfile_enable: bool,
+
+    pub read_ahead_options: Option<ReadAheadConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReadAheadConfig {
+    // todo: add more options
+    #[serde(default = "as_default_read_ahead_batch_size")]
+    batch_size: String,
+}
+
+fn as_default_read_ahead_batch_size() -> String {
+    "14M".to_string()
 }
 
 fn as_default_read_io_sendfile_enable() -> bool {
@@ -211,6 +224,7 @@ impl LocalfileStoreConfig {
             index_consistency_detection_enable: false,
             io_limiter: None,
             read_io_sendfile_enable: as_default_read_io_sendfile_enable(),
+            read_ahead_options: None,
         }
     }
 }

--- a/riffle-server/src/store/local/delegator.rs
+++ b/riffle-server/src/store/local/delegator.rs
@@ -14,6 +14,7 @@ use crate::readable_size::ReadableSize;
 use crate::runtime::manager::RuntimeManager;
 use crate::store::local::io_layer_await_tree::AwaitTreeLayer;
 use crate::store::local::io_layer_metrics::MetricsLayer;
+use crate::store::local::io_layer_read_ahead::ReadAheadLayer;
 use crate::store::local::io_layer_retry::{IoLayerRetry, RETRY_MAX_TIMES};
 use crate::store::local::io_layer_throttle::{ThrottleLayer, ThroughputBasedRateLimiter};
 use crate::store::local::io_layer_timeout::TimeoutLayer;
@@ -103,6 +104,10 @@ impl LocalDiskDelegator {
                 "IO layer of throttle is enabled for disk: {}. throughput: {}/s",
                 root, conf.capacity
             );
+        }
+        if let Some(_) = config.read_ahead_options.as_ref() {
+            operator_builder = operator_builder.layer(ReadAheadLayer::new(root));
+            info!("Read ahead layer is enabled for disk: {}.", root);
         }
         let io_handler = operator_builder
             .layer(TimeoutLayer::new(config.io_duration_threshold_sec))

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -148,7 +148,7 @@ impl ReadAheadTask {
     async fn do_read_ahead(&self, inner: &Inner, off: u64, len: u64) {
         info!(
             "Read ahead: {} with offset: {}, length: {}",
-            inner.absolute_path, inner.load_start_offset, len
+            inner.absolute_path, off, len
         );
         if let Err(e) = read_ahead(&inner.file, off as i64, len as i64) {
             // ignore failure

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use clap::builder::Str;
 use dashmap::DashMap;
 use libc::abs;
-use log::{info, warn};
+use log::{debug, info, warn};
 use parking_lot::Mutex;
 use std::fs::File;
 use std::sync::Arc;
@@ -146,7 +146,7 @@ impl ReadAheadTask {
     }
 
     async fn do_read_ahead(&self, inner: &Inner, off: u64, len: u64) {
-        info!(
+        debug!(
             "Read ahead: {} with offset: {}, length: {}",
             inner.absolute_path, off, len
         );

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -223,7 +223,11 @@ mod tests {
 
         let layer = ReadAheadLayer::new(root.as_str());
         let inner_handler: Arc<Box<dyn LocalIO>> = Arc::new(Box::new(MockHandler::new()));
-        let wrapped = layer.wrap(inner_handler);
+        let wrapped = ReadAheadLayerWrapper {
+            handler: inner_handler,
+            root: root.to_owned(),
+            load_tasks: Default::default(),
+        };
 
         // 1st read ahead
         let options = ReadOptions {
@@ -235,6 +239,9 @@ mod tests {
 
         let result = wrapped.read(file_name.as_str(), options).await;
         assert!(result.is_ok());
+
+        wrapped.delete(root.as_str()).await.unwrap();
+        assert_eq!(0, wrapped.load_tasks.len());
     }
 
     struct MockHandler;

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -69,7 +69,7 @@ impl LocalIO for ReadAheadLayerWrapper {
             let abs_path = format!("{}/{}", &self.root, path);
             let load_task = self
                 .load_tasks
-                .entry(self.root.to_owned())
+                .entry(path.to_owned())
                 .or_insert_with(|| match ReadAheadTask::new(&abs_path) {
                     Ok(task) => Some(task),
                     Err(_) => None,

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -1,0 +1,259 @@
+use crate::error::WorkerError;
+use crate::store::local::layers::{Handler, Layer};
+use crate::store::local::options::{CreateOptions, ReadOptions, WriteOptions};
+use crate::store::local::{FileStat, LocalIO};
+use crate::store::DataBytes;
+use crate::system_libc::read_ahead;
+use async_trait::async_trait;
+use clap::builder::Str;
+use dashmap::DashMap;
+use libc::abs;
+use log::{info, warn};
+use parking_lot::Mutex;
+use std::fs::File;
+use std::sync::Arc;
+
+const BATCH_SIZE: usize = 1024 * 1024 * 14;
+const BATCH_NUMBER: usize = 4;
+
+pub struct ReadAheadLayer {
+    root: String,
+}
+
+impl ReadAheadLayer {
+    pub fn new(root: &str) -> Self {
+        Self {
+            root: root.to_owned(),
+        }
+    }
+}
+
+impl Layer for ReadAheadLayer {
+    fn wrap(&self, handler: Handler) -> Handler {
+        Arc::new(Box::new(ReadAheadLayerWrapper {
+            handler,
+            root: self.root.to_owned(),
+            load_tasks: Arc::new(Default::default()),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct ReadAheadLayerWrapper {
+    handler: Handler,
+    root: String,
+
+    // todo: add purge logic
+    load_tasks: Arc<DashMap<String, Option<ReadAheadTask>>>,
+}
+
+unsafe impl Send for ReadAheadLayerWrapper {}
+unsafe impl Sync for ReadAheadLayerWrapper {}
+
+#[async_trait]
+impl LocalIO for ReadAheadLayerWrapper {
+    async fn create(&self, path: &str, options: CreateOptions) -> anyhow::Result<(), WorkerError> {
+        self.handler.create(path, options).await
+    }
+
+    async fn write(&self, path: &str, options: WriteOptions) -> anyhow::Result<(), WorkerError> {
+        self.handler.write(path, options).await
+    }
+
+    async fn read(
+        &self,
+        path: &str,
+        options: ReadOptions,
+    ) -> anyhow::Result<DataBytes, WorkerError> {
+        if options.length.is_some() {
+            let abs_path = format!("{}/{}", &self.root, path);
+            let load_task = self
+                .load_tasks
+                .entry(abs_path.to_owned())
+                .or_insert_with(|| match ReadAheadTask::new(&abs_path) {
+                    Ok(task) => Some(task),
+                    Err(_) => None,
+                });
+            if let Some(task) = load_task.value() {
+                task.load(options.offset, options.length.unwrap()).await?;
+            }
+        }
+        self.handler.read(&path, options).await
+    }
+
+    async fn delete(&self, path: &str) -> anyhow::Result<(), WorkerError> {
+        self.handler.delete(path).await
+    }
+
+    async fn file_stat(&self, path: &str) -> anyhow::Result<FileStat, WorkerError> {
+        self.handler.file_stat(path).await
+    }
+}
+
+struct ReadAheadTask {
+    inner: Arc<tokio::sync::Mutex<Inner>>,
+}
+
+struct Inner {
+    absolute_path: String,
+    file: File,
+
+    is_initialized: bool,
+    load_start_offset: u64,
+    load_length: u64,
+}
+
+impl ReadAheadTask {
+    fn new(abs_path: &str) -> anyhow::Result<Self> {
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(abs_path)?;
+        Ok(Self {
+            inner: Arc::new(tokio::sync::Mutex::new(Inner {
+                absolute_path: abs_path.to_string(),
+                file,
+                is_initialized: false,
+                load_start_offset: 0,
+                load_length: 0,
+            })),
+        })
+    }
+
+    async fn do_read_ahead(&self, inner: &Inner, off: u64, len: u64) {
+        info!(
+            "Read ahead: {} with offset: {}, length: {}",
+            inner.absolute_path, inner.load_start_offset, len
+        );
+        if let Err(e) = read_ahead(&inner.file, off as i64, len as i64) {
+            // ignore failure
+            warn!(
+                "Errors on reading ahead: {} with offset: {}, length: {}",
+                &inner.absolute_path, off, len
+            );
+        }
+    }
+
+    async fn load(&self, off: u64, len: u64) -> anyhow::Result<bool> {
+        let mut inner = self.inner.lock().await;
+        if !inner.is_initialized && off == 0 {
+            let load_len = (BATCH_NUMBER * BATCH_SIZE) as u64;
+            self.do_read_ahead(&inner, 0, load_len).await;
+            inner.is_initialized = true;
+            inner.load_length = load_len;
+            return Ok(true);
+        }
+
+        let diff = inner.load_length - off;
+        let next_load_bytes = 2 * BATCH_NUMBER as u64;
+        if diff > 0 && diff < next_load_bytes {
+            let load_len = next_load_bytes;
+            self.do_read_ahead(
+                &inner,
+                inner.load_start_offset + inner.load_length,
+                load_len,
+            )
+            .await;
+            inner.load_length += load_len;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::WorkerError;
+    use crate::store::local::options::ReadOptions;
+    use crate::store::local::FileStat;
+    use crate::store::local::{CreateOptions, LocalIO, WriteOptions};
+    use crate::store::DataBytes;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use log::SetLoggerError;
+    use std::io::Write;
+    use std::path::Path;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+
+    fn init_logger() -> Result<(), SetLoggerError> {
+        env_logger::builder().is_test(true).try_init()
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_read_ahead() {
+        let _logger = init_logger();
+
+        // Prepare temp file path and content
+        let mut temp_file = NamedTempFile::new().expect("create temp file");
+        let content = b"hello riffle read ahead";
+        temp_file.write_all(content).unwrap();
+        let temp_path = temp_file.path().to_str().unwrap().to_string();
+        let path = Path::new(&temp_path);
+        let root = path.parent().unwrap().to_str().unwrap().to_string();
+        let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        let layer = ReadAheadLayer::new(root.as_str());
+        let inner_handler: Arc<Box<dyn LocalIO>> = Arc::new(Box::new(MockHandler::new()));
+        let wrapped = layer.wrap(inner_handler);
+
+        // 1st read ahead
+        let options = ReadOptions {
+            sendfile: false,
+            direct_io: false,
+            offset: 0,
+            length: Some(5),
+        };
+
+        let result = wrapped.read(file_name.as_str(), options).await;
+        assert!(result.is_ok());
+    }
+
+    struct MockHandler;
+
+    impl MockHandler {
+        fn new() -> Self {
+            MockHandler
+        }
+    }
+
+    #[async_trait]
+    impl LocalIO for MockHandler {
+        async fn create(
+            &self,
+            _path: &str,
+            _options: CreateOptions,
+        ) -> anyhow::Result<(), WorkerError> {
+            Ok(())
+        }
+
+        async fn write(
+            &self,
+            _path: &str,
+            _options: WriteOptions,
+        ) -> anyhow::Result<(), WorkerError> {
+            Ok(())
+        }
+
+        async fn read(
+            &self,
+            _path: &str,
+            _options: ReadOptions,
+        ) -> anyhow::Result<DataBytes, WorkerError> {
+            Ok(DataBytes::Direct(Bytes::from(b"mock".to_vec())))
+        }
+
+        async fn delete(&self, _path: &str) -> anyhow::Result<(), WorkerError> {
+            Ok(())
+        }
+
+        async fn file_stat(&self, _path: &str) -> anyhow::Result<FileStat, WorkerError> {
+            Ok(FileStat { content_length: 0 })
+        }
+    }
+}

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -67,13 +67,13 @@ impl LocalIO for ReadAheadLayerWrapper {
     ) -> anyhow::Result<DataBytes, WorkerError> {
         if options.length.is_some() {
             let abs_path = format!("{}/{}", &self.root, path);
-            let load_task = self
-                .load_tasks
-                .entry(path.to_owned())
-                .or_insert_with(|| match ReadAheadTask::new(&abs_path) {
-                    Ok(task) => Some(task),
-                    Err(_) => None,
-                });
+            let load_task =
+                self.load_tasks
+                    .entry(path.to_owned())
+                    .or_insert_with(|| match ReadAheadTask::new(&abs_path) {
+                        Ok(task) => Some(task),
+                        Err(_) => None,
+                    });
             if let Some(task) = load_task.value() {
                 task.load(options.offset, options.length.unwrap()).await?;
             }

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -170,7 +170,7 @@ impl ReadAheadTask {
         }
 
         let diff = inner.load_length - off;
-        let next_load_bytes = 2 * BATCH_NUMBER as u64;
+        let next_load_bytes = 2 * BATCH_SIZE as u64;
         if diff > 0 && diff < next_load_bytes {
             let load_len = next_load_bytes;
             self.do_read_ahead(

--- a/riffle-server/src/store/local/mod.rs
+++ b/riffle-server/src/store/local/mod.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 pub mod delegator;
 mod io_layer_await_tree;
 mod io_layer_metrics;
+pub mod io_layer_read_ahead;
 mod io_layer_retry;
 pub mod io_layer_throttle;
 mod io_layer_timeout;

--- a/riffle-server/src/system_libc.rs
+++ b/riffle-server/src/system_libc.rs
@@ -129,6 +129,31 @@ pub async fn send_file_full(
     Ok(())
 }
 
+pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> Result<()> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::io::AsRawFd;
+        unsafe {
+            let fd = file.as_raw_fd();
+            let res = libc::posix_fadvise(
+                fd,
+                off as libc::off_t,
+                len as libc::off_t,
+                libc::POSIX_FADV_WILLNEED,
+            );
+            if res != 0 {
+                return Err(std::io::Error::from_raw_os_error(res));
+            }
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod tests {

--- a/riffle-server/src/system_libc.rs
+++ b/riffle-server/src/system_libc.rs
@@ -147,7 +147,7 @@ pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> Result<()> {
                 libc::POSIX_FADV_WILLNEED,
             );
             if res != 0 {
-                return Err(std::io::Error::from_raw_os_error(res));
+                return Err(std::io::Error::from_raw_os_error(res).into());
             }
             Ok(())
         }


### PR DESCRIPTION
Linked with https://github.com/zuston/riffle/pull/295

# Test Setup

1. 10 concurrent threads
2. Reading 1GB of data
3. Batch size: 14MB
4. Page cache was cleared before each test (ensured manually)

# Benchmark Result

<img width="1763" height="496" alt="image" src="https://github.com/user-attachments/assets/c895fad7-3269-4bc5-9e80-0718fa736645" />
