### PR TITLE
feat: Fallback to localfile on huge partition writing hdfs failure

### DIFF
--- a/riffle-server/src/app_manager.rs
+++ b/riffle-server/src/app_manager.rs
@@ -493,6 +493,7 @@ pub(crate) mod test {
                 memory_spill_to_localfile_concurrency: None,
                 memory_spill_to_hdfs_concurrency: None,
                 huge_partition_memory_spill_to_hdfs_threshold_size: "64M".to_string(),
+                huge_partition_fallback_enable: false,
                 sensitive_watermark_spill_enable: false,
                 async_watermark_spill_trigger_enable: false,
                 async_watermark_spill_trigger_interval_ms: 0,

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -285,6 +285,8 @@ pub struct HybridStoreConfig {
 
     #[serde(default = "as_default_huge_partition_memory_spill_to_hdfs_threshold_size")]
     pub huge_partition_memory_spill_to_hdfs_threshold_size: String,
+    #[serde(default = "as_default_huge_partition_fallback_enable")]
+    pub huge_partition_fallback_enable: bool,
 
     #[serde(default = "as_default_sensitive_watermark_spill_enable")]
     pub sensitive_watermark_spill_enable: bool,
@@ -293,6 +295,10 @@ pub struct HybridStoreConfig {
     pub async_watermark_spill_trigger_enable: bool,
     #[serde(default = "as_default_async_watermark_spill_trigger_interval_ms")]
     pub async_watermark_spill_trigger_interval_ms: u64,
+}
+
+fn as_default_huge_partition_fallback_enable() -> bool {
+    false
 }
 
 fn as_default_async_watermark_spill_trigger_interval_ms() -> u64 {
@@ -338,6 +344,7 @@ impl HybridStoreConfig {
             memory_spill_to_hdfs_concurrency: None,
             huge_partition_memory_spill_to_hdfs_threshold_size:
                 as_default_huge_partition_memory_spill_to_hdfs_threshold_size(),
+            huge_partition_fallback_enable: as_default_huge_partition_fallback_enable(),
             sensitive_watermark_spill_enable: as_default_sensitive_watermark_spill_enable(),
             async_watermark_spill_trigger_enable: as_default_async_watermark_spill_trigger_enable(),
             async_watermark_spill_trigger_interval_ms:
@@ -357,6 +364,7 @@ impl Default for HybridStoreConfig {
             memory_spill_to_hdfs_concurrency: None,
             huge_partition_memory_spill_to_hdfs_threshold_size:
                 as_default_huge_partition_memory_spill_to_hdfs_threshold_size(),
+            huge_partition_fallback_enable: as_default_huge_partition_fallback_enable(),
             sensitive_watermark_spill_enable: as_default_sensitive_watermark_spill_enable(),
             async_watermark_spill_trigger_enable: as_default_async_watermark_spill_trigger_enable(),
             async_watermark_spill_trigger_interval_ms:

--- a/riffle-server/src/lib.rs
+++ b/riffle-server/src/lib.rs
@@ -17,6 +17,7 @@
 
 #![allow(dead_code, unused)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(let_chains)]
 
 pub mod app_manager;
 pub mod await_tree;

--- a/riffle-server/src/main.rs
+++ b/riffle-server/src/main.rs
@@ -17,6 +17,7 @@
 
 #![allow(dead_code, unused)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(let_chains)]
 
 use crate::app_manager::{AppManager, APP_MANAGER_REF};
 use crate::common::init_global_variable;

--- a/riffle-server/src/store/hybrid.rs
+++ b/riffle-server/src/store/hybrid.rs
@@ -371,6 +371,7 @@ impl HybridStore {
                             && stype == StorageType::HDFS
                             && spill_message.get_retry_counter() > 1
                             && warm.is_healthy().await?
+                            && self.config.huge_partition_fallback_enable
                         {
                             candidate_store = warm;
                             info!(

--- a/riffle-server/src/store/spill/spill_test.rs
+++ b/riffle-server/src/store/spill/spill_test.rs
@@ -443,6 +443,7 @@ mod tests {
         config
             .hybrid_store
             .huge_partition_memory_spill_to_hdfs_threshold_size = "1B".to_string();
+        config.hybrid_store.huge_partition_fallback_enable = true;
 
         let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
         let store = create_hybrid_store(&config, &warm, Some(&cold), &reconf_manager);


### PR DESCRIPTION
# Background

When partition splitting is enabled, a single huge partition’s data can be distributed across multiple Riffle servers. However, based on metrics and logs, some huge partitions still write small amounts of data to HDFS, which is relatively insignificant compared to previous cases.

Although the frequency of HDFS flushes has decreased, any failure during HDFS flushing can result in data loss (#410 / #395), which is harmful to Spark applications.

This PR introduces a fallback mechanism: if flushing to HDFS fails, the data will be redirected to the local file system, assuming that the local storage is capable of handling the additional load.

# How to use

This PR introduces a dedicated configuration option to enable this fallback feature. By default, the feature is disabled to avoid impacting existing behavior.

`huge_partition_fallback_enable=false`