### PR TITLE
feat: Add cluster ids config to simplify specify coordinator url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,7 +2089,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2100,8 +2109,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5055,6 +5076,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5198,6 +5230,7 @@ dependencies = [
  "dashmap 5.5.3",
  "datafusion",
  "datafusion-postgres",
+ "dirs 6.0.0",
  "env_logger 0.10.2",
  "futures",
  "indicatif",
@@ -5214,6 +5247,7 @@ dependencies = [
  "strum_macros 0.20.1",
  "tempfile",
  "tokio",
+ "toml 0.7.8",
  "url",
 ]
 
@@ -6397,7 +6431,7 @@ dependencies = [
  "color-eyre",
  "console-api",
  "crossterm",
- "dirs",
+ "dirs 5.0.1",
  "futures",
  "h2 0.4.10",
  "hdrhistogram",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ pgwire = "0.28.0"
 datafusion-postgres = { git = "https://github.com/zuston/datafusion-postgres.git", branch = "extended" }
 sqlparser = "0.56.0"
 nix = { version = "0.29.0" }
+dirs = { version = "6.0.0" }
 
 [profile.release]
 debug = 1

--- a/riffle-ctl/Cargo.toml
+++ b/riffle-ctl/Cargo.toml
@@ -40,6 +40,8 @@ sqlparser = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
 logforth = { workspace = true }
+toml = { workspace = true }
+dirs = { workspace = true }
 
 [dev-dependencies]
 poem = { workspace = true, features = ["rustls", "test", "anyhow"] }

--- a/riffle-ctl/src/meta.rs
+++ b/riffle-ctl/src/meta.rs
@@ -1,0 +1,139 @@
+use log::{debug, error, info};
+use riffle_server::config::Config;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[macro_export]
+macro_rules! unwrap_or_return_empty_map {
+    ($expr:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(e) => {
+                debug!("err: {}", e);
+                return ::std::collections::HashMap::new();
+            }
+        }
+    };
+}
+
+fn default_meta_file_path() -> String {
+    let path = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".riffle")
+        .join("meta.file");
+    path.to_str().unwrap().to_string()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+struct ClusterConfigs {
+    clusters: Vec<ClusterId>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+struct ClusterId {
+    cluster_id: String,
+    coordinator_url: String,
+}
+
+pub struct Metadata {
+    meta_file_path: String,
+}
+
+impl Metadata {
+    // Load the config file from the meta file
+    pub fn load(meta_path: Option<&str>) -> Self {
+        let meta_path = if let Some(p) = meta_path {
+            p
+        } else {
+            &default_meta_file_path()
+        };
+
+        Self {
+            meta_file_path: meta_path.into(),
+        }
+    }
+
+    // Only valid for initialization
+    pub fn create(meta_path: Option<&str>, config_path: &str) -> Self {
+        let meta_path = if let Some(p) = meta_path {
+            p
+        } else {
+            &default_meta_file_path()
+        };
+        info!("meta file path: {}", meta_path);
+
+        let parent_dir = Path::new(meta_path).parent().unwrap();
+        fs::create_dir_all(parent_dir).unwrap();
+
+        let content = fs::read_to_string(config_path).expect("Failed to read config file");
+        let _: ClusterConfigs = toml::from_str(&content).expect("Invalid config file");
+
+        // Store the config file path into meta file
+        fs::write(meta_path, config_path).expect("Failed to write meta file");
+
+        Self {
+            meta_file_path: meta_path.into(),
+        }
+    }
+
+    pub fn get_cluster_ids(&self) -> HashMap<String, String> {
+        let config_path = unwrap_or_return_empty_map!(fs::read_to_string(&self.meta_file_path));
+
+        let content = unwrap_or_return_empty_map!(fs::read_to_string(config_path.trim()));
+        let config: ClusterConfigs = unwrap_or_return_empty_map!(toml::from_str(&content));
+
+        config
+            .clusters
+            .iter()
+            .map(|c| (c.cluster_id.clone(), c.coordinator_url.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_empty() {
+        let dir = tempdir().unwrap();
+        let meta_path = dir.path().join("meta.file");
+
+        let meta = Metadata::load(meta_path.to_str());
+        assert_eq!(0, meta.get_cluster_ids().len());
+    }
+
+    #[test]
+    fn test_create_and_get_cluster_ids() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("test_config.toml");
+        let meta_path = dir.path().join("meta.file");
+
+        let config_content = r#"
+            [[clusters]]
+            cluster_id = "abc"
+            coordinator_url = "http://localhost:12345"
+        "#;
+        fs::write(&config_path, config_content).unwrap();
+
+        let metadata = Metadata::create(
+            Some(meta_path.to_str().unwrap()),
+            config_path.to_str().unwrap(),
+        );
+
+        assert_eq!(metadata.meta_file_path, meta_path.to_str().unwrap());
+
+        fs::write(&meta_path, config_path.to_str().unwrap()).unwrap();
+
+        let metadata2 = Metadata {
+            meta_file_path: meta_path.to_str().unwrap().to_string(),
+        };
+
+        let clusters = metadata2.get_cluster_ids();
+        assert_eq!(clusters.get("abc").unwrap(), "http://localhost:12345");
+    }
+}


### PR DESCRIPTION
This PR is to introduce the config to simplify the coordinator url into simple name.

You could specify the config.toml like as follows

```
[[clusters]]
cluster_id= "s1"
coordinator_url= "http://xxxx:21001"
```

And you could specify the config file by the following command

`./riffle-ctl -c /tmp/config.toml`

And then you could use the simple name to query 

`./riffle-ctl query -c s1 --sql "select * from instances"`