### PR TITLE
feat(urpc): Add support of task_ids filter on memory getting rpc

### DIFF
--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -230,7 +230,7 @@ impl App {
         self.heartbeat()?;
 
         let ctx = if (self.app_config_options.sendfile_enable) {
-            ReadingViewContext::with_sendfile_enabled(ctx)
+            ctx.with_sendfile_enabled()
         } else {
             ctx
         };

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -112,21 +112,6 @@ pub enum RpcType {
 }
 
 impl ReadingViewContext {
-    pub fn with_task_ids_filter(
-        uid: PartitionUId,
-        reading_options: ReadingOptions,
-        bitmap: Treemap,
-        rpc_source: RpcType,
-    ) -> Self {
-        ReadingViewContext {
-            uid,
-            reading_options,
-            task_ids_filter: Some(bitmap),
-            rpc_source,
-            sendfile_enabled: false,
-        }
-    }
-
     pub fn new(uid: PartitionUId, reading_options: ReadingOptions, rpc_source: RpcType) -> Self {
         ReadingViewContext {
             uid,
@@ -137,12 +122,22 @@ impl ReadingViewContext {
         }
     }
 
-    pub fn with_sendfile_enabled(ctx: ReadingViewContext) -> Self {
-        Self {
-            uid: ctx.uid,
-            reading_options: ctx.reading_options,
-            task_ids_filter: ctx.task_ids_filter,
-            rpc_source: ctx.rpc_source,
+    pub fn with_task_ids_filter(&self, bitmap: Treemap) -> Self {
+        ReadingViewContext {
+            uid: self.uid.clone(),
+            reading_options: self.reading_options.clone(),
+            task_ids_filter: Some(bitmap),
+            rpc_source: self.rpc_source.clone(),
+            sendfile_enabled: self.sendfile_enabled,
+        }
+    }
+
+    pub fn with_sendfile_enabled(&self) -> Self {
+        ReadingViewContext {
+            uid: self.uid.clone(),
+            reading_options: self.reading_options.clone(),
+            task_ids_filter: self.task_ids_filter.clone(),
+            rpc_source: self.rpc_source.clone(),
             sendfile_enabled: true,
         }
     }

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -674,17 +674,13 @@ impl ShuffleServer for DefaultShuffleServer {
             req.last_block_id,
             req.read_buffer_size as i64,
         );
+        let ctx = ReadingViewContext::new(partition_id.clone(), reading_options, RpcType::GRPC);
         let reading_ctx = if !req.serialized_expected_task_ids_bitmap.is_empty() {
             let bitmap =
                 Treemap::deserialize::<JvmLegacy>(&req.serialized_expected_task_ids_bitmap);
-            ReadingViewContext::with_task_ids_filter(
-                partition_id.clone(),
-                reading_options,
-                bitmap,
-                RpcType::GRPC,
-            )
+            ctx.with_task_ids_filter(bitmap)
         } else {
-            ReadingViewContext::new(partition_id.clone(), reading_options, RpcType::GRPC)
+            ctx
         };
 
         let data_fetched_result = app

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -15,6 +15,7 @@ use crate::util;
 use anyhow::Result;
 use await_tree::InstrumentAwait;
 use bytes::Bytes;
+use croaring::{JvmLegacy, Treemap};
 use log::{debug, error};
 use std::collections::HashMap;
 
@@ -94,14 +95,29 @@ impl GetMemoryDataRequestCommand {
 
         let app = app.unwrap();
         let uid = PartitionUId::new(&application_id, shuffle_id, partition_id);
-        let ctx = ReadingViewContext::new(
-            uid,
-            ReadingOptions::MEMORY_LAST_BLOCK_ID_AND_MAX_SIZE(
-                last_block_id,
-                read_buffer_size as i64,
+
+        let ctx = match &self.expected_tasks_bitmap_raw {
+            Some(raw) => {
+                let bitmap = Treemap::deserialize::<JvmLegacy>(raw);
+                ReadingViewContext::with_task_ids_filter(
+                    uid,
+                    ReadingOptions::MEMORY_LAST_BLOCK_ID_AND_MAX_SIZE(
+                        last_block_id,
+                        read_buffer_size as i64,
+                    ),
+                    bitmap,
+                    RpcType::URPC,
+                )
+            }
+            _ => ReadingViewContext::new(
+                uid,
+                ReadingOptions::MEMORY_LAST_BLOCK_ID_AND_MAX_SIZE(
+                    last_block_id,
+                    read_buffer_size as i64,
+                ),
+                RpcType::URPC,
             ),
-            RpcType::URPC,
-        );
+        };
 
         let response = match app.select(ctx).await {
             Err(e) => GetMemoryDataResponseCommand {


### PR DESCRIPTION
This PR aligns the implementation with gRPC, aiming to reduce shuffle read time for tasks—particularly those affected by AQE (Adaptive Query Execution) rules.