### PR TITLE
fix: Use the fixed rustc version to bypass build failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "master"
-      - "fixRelease"
+      - "sendSync"
     tags:
       - "v*.*.*"
   pull_request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "sendSync"
     tags:
       - "v*.*.*"
   pull_request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2025-06-01
           override: true
 
       - name: Build


### PR DESCRIPTION
### build failure

1. https://github.com/zuston/riffle/actions/runs/16901198646/job/47880539918#step:8:936

<img width="1228" height="390" alt="image" src="https://github.com/user-attachments/assets/0642cef0-23f5-4d89-a0b7-44f7dea78ba4" />
