### PR TITLE
feat(read-ahead)(4/N): Add more metrics

### DIFF
--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -124,9 +124,9 @@ impl App {
 
         let block_id_manager = get_block_id_manager(&config.app_config.block_id_manager_type);
 
-        info!("App=[{}]. sendfile_enable: {}. block_manager_type: {}. partition_limit/threshold/ratio: {}/{}/{}. partition_split/threshold: {}/{}",
+        info!("App=[{}]. {}. block_manager_type: {}. partition_limit/threshold/ratio: {}/{}/{}. partition_split/threshold: {}/{}",
             &app_id,
-            config_options.sendfile_enable,
+            &config_options,
             &config.app_config.block_id_manager_type,
             partition_limit_enable,
             partition_limit_threshold.get(),

--- a/riffle-server/src/app_manager/app_configs.rs
+++ b/riffle-server/src/app_manager/app_configs.rs
@@ -5,10 +5,12 @@ use crate::client_configs::{
 use crate::grpc::protobuf::uniffle::RemoteStorage;
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::{Display, Formatter};
+use strum_macros::Display;
 
 pub const MAX_CONCURRENCY_PER_PARTITION_TO_WRITE: i32 = 20;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
 pub enum DataDistribution {
     NORMAL,
     #[allow(non_camel_case_types)]
@@ -53,6 +55,16 @@ impl Default for AppConfigOptions {
             read_ahead_enable: false,
             client_configs: Default::default(),
         }
+    }
+}
+
+impl Display for AppConfigOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "data_distribution={}, sendfile_enable={}, read_ahead_enable={}",
+            &self.data_distribution, self.sendfile_enable, self.read_ahead_enable
+        )
     }
 }
 

--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -688,6 +688,86 @@ pub static TOTAL_DETECTED_LOCALFILE_IN_CONSISTENCY: Lazy<IntCounter> = Lazy::new
     .expect("")
 });
 
+// Read-ahead related metrics - without root tag
+pub static READ_AHEAD_IGNORES: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new("read_ahead_ignores", "Number of read-ahead cache ignores")
+        .expect("metric should be created")
+});
+pub static READ_AHEAD_HITS: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new("read_ahead_hits", "Number of read-ahead cache hits")
+        .expect("metric should be created")
+});
+
+pub static READ_AHEAD_MISSES: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new("read_ahead_misses", "Number of read-ahead cache misses")
+        .expect("metric should be created")
+});
+
+// Read-ahead performance metrics
+pub static READ_WITH_AHEAD_HIT_DURATION: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_with_ahead_hit_duration_seconds",
+        "Duration of reads that hit read-ahead cache",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
+pub static READ_WITH_AHEAD_MISS_DURATION: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_with_ahead_miss_duration_seconds",
+        "Duration of reads that miss read-ahead cache",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
+pub static READ_WITHOUT_AHEAD_DURATION: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_without_ahead_duration_seconds",
+        "Duration of reads without read-ahead (non-sequential)",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
+pub static READ_AHEAD_OPERATIONS: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "read_ahead_operations",
+        "Total number of read-ahead operations performed",
+    )
+    .expect("metric should be created")
+});
+
+pub static READ_AHEAD_BYTES: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new("read_ahead_bytes", "Total bytes read ahead").expect("metric should be created")
+});
+
+pub static READ_AHEAD_WASTED_BYTES: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "read_ahead_wasted_bytes",
+        "Bytes read ahead but never actually read",
+    )
+    .expect("metric should be created")
+});
+
+pub static READ_AHEAD_ACTIVE_TASKS: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        "read_ahead_active_tasks",
+        "Number of active read-ahead tasks",
+    )
+    .expect("metric should be created")
+});
+
+pub static READ_AHEAD_OPERATION_DURATION: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_ahead_operation_duration_seconds",
+        "Duration of read-ahead operations",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
 // total timeout tickets
 pub static TOTAL_EVICT_TIMEOUT_TICKETS_NUM: Lazy<IntCounter> = Lazy::new(|| {
     IntCounter::new(
@@ -1050,6 +1130,41 @@ fn register_custom_metrics() {
     REGISTRY
         .register(Box::new(TOTAL_DETECTED_LOCALFILE_IN_CONSISTENCY.clone()))
         .expect("");
+
+    // Register read-ahead metrics
+    REGISTRY
+        .register(Box::new(READ_AHEAD_IGNORES.clone()))
+        .expect("read_ahead_ignores must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_HITS.clone()))
+        .expect("read_ahead_hits must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_MISSES.clone()))
+        .expect("read_ahead_misses must be registered");
+    REGISTRY
+        .register(Box::new(READ_WITH_AHEAD_HIT_DURATION.clone()))
+        .expect("read_with_ahead_hit_duration must be registered");
+    REGISTRY
+        .register(Box::new(READ_WITH_AHEAD_MISS_DURATION.clone()))
+        .expect("read_with_ahead_miss_duration must be registered");
+    REGISTRY
+        .register(Box::new(READ_WITHOUT_AHEAD_DURATION.clone()))
+        .expect("read_without_ahead_duration must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_OPERATIONS.clone()))
+        .expect("read_ahead_operations must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_BYTES.clone()))
+        .expect("read_ahead_bytes must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_WASTED_BYTES.clone()))
+        .expect("read_ahead_wasted_bytes must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_ACTIVE_TASKS.clone()))
+        .expect("read_ahead_active_tasks must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_OPERATION_DURATION.clone()))
+        .expect("read_ahead_operation_duration must be registered");
 }
 
 const JOB_NAME: &str = "uniffle-worker";


### PR DESCRIPTION



          
# Read-Ahead Performance Metrics Implementation Summary

## New Metrics Added

### 1. Latency Comparison Metrics (3 metrics)
- `read_ahead_hit_duration_seconds` - Read latency when cache hit
- `read_ahead_miss_duration_seconds` - Read latency when cache miss  
- `read_ahead_non_duration_seconds` - Baseline latency without read-ahead

### 2. Cache Performance Metrics (2 metrics)
- `read_ahead_hits_total` - Cache hit count
- `read_ahead_misses_total` - Cache miss count

### 3. Read-Ahead Operation Metrics (4 metrics)
- `read_ahead_operations_total` - Total read-ahead operations
- `read_ahead_bytes_total` - Total bytes read by read-ahead
- `read_ahead_wasted_bytes_total` - Wasted bytes (preloaded but unused)
- `read_ahead_operation_duration_seconds` - Read-ahead operation duration

## Key Prometheus Queries

### Performance Comparison
```promql
# Hit vs Miss latency comparison
rate(read_ahead_hit_duration_seconds_sum[5m]) / rate(read_ahead_hit_duration_seconds_count[5m])
vs
rate(read_ahead_miss_duration_seconds_sum[5m]) / rate(read_ahead_miss_duration_seconds_count[5m])
```

### Cache Hit Rate
```promql
# Overall hit rate
rate(read_ahead_hits_total[5m]) / (rate(read_ahead_hits_total[5m]) + rate(read_ahead_misses_total[5m])) * 100
```

### Efficiency Assessment
```promql
# Byte utilization rate
(rate(read_ahead_bytes_total[5m]) - rate(read_ahead_wasted_bytes_total[5m])) / rate(read_ahead_bytes_total[5m]) * 100
```

### Performance Improvement
```promql
# Latency improvement percentage (hit vs baseline)
(1 - (rate(read_ahead_hit_duration_seconds_sum[5m]) / rate(read_ahead_hit_duration_seconds_count[5m])) / (rate(read_ahead_non_duration_seconds_sum[5m]) / rate(read_ahead_non_duration_seconds_count[5m]))) * 100
```

## Success Criteria

- **Hit Rate**: >70% for effectiveness
- **Latency Improvement**: Hit latency should be significantly lower than baseline
- **Efficiency**: Waste ratio <30%
- **Overall Performance**: Weighted average latency better than baseline

These metrics provide comprehensive visibility into read-ahead performance and effectiveness evaluation.
        