### PR TITLE
feat(read-ahead): Accept read plan and then to prefetch to adapt AQE skew optimization

### DIFF
--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -51,7 +51,11 @@ impl DiskReadBenchAction {
         ));
         if read_ahead_enable {
             let options = ReadAheadConfig::default();
-            builder = builder.layer(ReadAheadLayer::new(dir.as_str(), &options));
+            builder = builder.layer(ReadAheadLayer::new(
+                dir.as_str(),
+                &options,
+                write_runtime.clone(),
+            ));
             info!("Read ahead layer is enabled.");
         }
         let handler = Arc::new(builder.build());

--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -4,7 +4,7 @@ use crate::Commands::DiskAppendBench;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::info;
 use riffle_server::config::{IoLimiterConfig, ReadAheadConfig};
-use riffle_server::runtime::manager::create_runtime;
+use riffle_server::runtime::manager::{create_runtime, RuntimeManager};
 use riffle_server::runtime::RuntimeRef;
 use riffle_server::store::local::io_layer_read_ahead::ReadAheadLayer;
 use riffle_server::store::local::layers::Handler;
@@ -54,7 +54,7 @@ impl DiskReadBenchAction {
             builder = builder.layer(ReadAheadLayer::new(
                 dir.as_str(),
                 &options,
-                write_runtime.clone(),
+                RuntimeManager::default(),
             ));
             info!("Read ahead layer is enabled.");
         }

--- a/riffle-server/src/app_manager.rs
+++ b/riffle-server/src/app_manager.rs
@@ -319,6 +319,10 @@ impl AppManager {
     pub fn runtime_manager(&self) -> RuntimeManager {
         self.runtime_manager.clone()
     }
+
+    pub fn get_config(&self) -> &Config {
+        &self.config
+    }
 }
 
 #[cfg(test)]

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -3,6 +3,7 @@ use crate::app_manager::partition_identifier::PartitionUId;
 use crate::app_manager::purge_event::PurgeReason;
 use crate::id_layout::IdLayout;
 use crate::store::Block;
+use crate::urpc::command::ReadSegment;
 use croaring::Treemap;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -108,6 +109,9 @@ pub struct ReadingViewContext {
     pub sequential: bool,
     pub read_ahead_batch_number: Option<usize>,
     pub read_ahead_batch_size: Option<usize>,
+
+    // next read segments
+    pub localfile_next_read_segments: Vec<ReadSegment>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,6 +131,7 @@ impl ReadingViewContext {
             sequential: false,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
+            localfile_next_read_segments: vec![],
         }
     }
 
@@ -149,6 +154,11 @@ impl ReadingViewContext {
         self.sequential = true;
         self.read_ahead_batch_number = batch_number;
         self.read_ahead_batch_size = batch_size;
+        self
+    }
+
+    pub fn with_localfile_next_read_segments(mut self, segments: Vec<ReadSegment>) -> Self {
+        self.localfile_next_read_segments = segments;
         self
     }
 }

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -112,6 +112,7 @@ pub struct ReadingViewContext {
 
     // next read segments
     pub localfile_next_read_segments: Vec<ReadSegment>,
+    pub task_id: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,6 +133,7 @@ impl ReadingViewContext {
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
+            task_id: 0,
         }
     }
 
@@ -159,6 +161,11 @@ impl ReadingViewContext {
 
     pub fn with_localfile_next_read_segments(mut self, segments: Vec<ReadSegment>) -> Self {
         self.localfile_next_read_segments = segments;
+        self
+    }
+
+    pub fn with_task_id(mut self, task_id: i64) -> Self {
+        self.task_id = task_id;
         self
     }
 }

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -460,6 +460,26 @@ pub struct Config {
 
     #[serde(default = "as_default_conf_reload_enable")]
     pub conf_reload_enable: bool,
+
+    pub urpc_config: Option<UrpcConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct UrpcConfig {
+    pub get_index_rpc_version: RpcVersion,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum RpcVersion {
+    V1,
+    V2,
+    V3,
+}
+
+impl Default for RpcVersion {
+    fn default() -> Self {
+        RpcVersion::V1
+    }
 }
 
 fn as_default_conf_reload_enable() -> bool {

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -147,6 +147,8 @@ pub struct ReadAheadConfig {
     #[serde(default = "as_default_read_ahead_batch_number")]
     pub batch_number: usize,
 
+    #[serde(default = "bool::default")]
+    pub read_plan_enable: bool,
     #[serde(default = "as_default_read_plan_concurrency")]
     pub read_plan_concurrency: usize,
 }
@@ -160,6 +162,7 @@ impl Default for ReadAheadConfig {
         Self {
             batch_size: as_default_read_ahead_batch_size(),
             batch_number: as_default_read_ahead_batch_number(),
+            read_plan_enable: false,
             read_plan_concurrency: as_default_read_plan_concurrency(),
         }
     }

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -770,7 +770,9 @@ impl Config {
 
 #[cfg(test)]
 mod test {
-    use crate::config::{as_default_app_heartbeat_timeout_min, Config, RuntimeConfig, StorageType};
+    use crate::config::{
+        as_default_app_heartbeat_timeout_min, Config, RpcVersion, RuntimeConfig, StorageType,
+    };
     use crate::readable_size::ReadableSize;
     use std::str::FromStr;
 
@@ -799,6 +801,9 @@ mod test {
         let toml_str = r#"
         store_type = "MEMORY_LOCALFILE"
         coordinator_quorum = ["xxxxxxx"]
+
+        [urpc_config]
+        get_index_rpc_version = "V2"
 
         [memory_store]
         capacity = "1024M"
@@ -832,6 +837,11 @@ mod test {
         assert_eq!(
             decoded.runtime_config.read_thread_num,
             RuntimeConfig::default().read_thread_num
+        );
+
+        assert_eq!(
+            RpcVersion::V2,
+            decoded.urpc_config.as_ref().unwrap().get_index_rpc_version
         );
 
         // check the app config

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -142,11 +142,17 @@ pub struct LocalfileStoreConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ReadAheadConfig {
-    // todo: add more options
     #[serde(default = "as_default_read_ahead_batch_size")]
     pub batch_size: String,
     #[serde(default = "as_default_read_ahead_batch_number")]
     pub batch_number: usize,
+
+    #[serde(default = "as_default_read_plan_concurrency")]
+    pub read_plan_concurrency: usize,
+}
+
+fn as_default_read_plan_concurrency() -> usize {
+    100
 }
 
 impl Default for ReadAheadConfig {
@@ -154,6 +160,7 @@ impl Default for ReadAheadConfig {
         Self {
             batch_size: as_default_read_ahead_batch_size(),
             batch_number: as_default_read_ahead_batch_number(),
+            read_plan_concurrency: as_default_read_plan_concurrency(),
         }
     }
 }

--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -775,6 +775,14 @@ pub static READ_AHEAD_WASTED_BYTES: Lazy<IntCounter> = Lazy::new(|| {
     .expect("metric should be created")
 });
 
+pub static TOTAL_READ_AHEAD_ACTIVE_TASKS: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "total_read_ahead_active_tasks",
+        "Total number of active read-ahead tasks",
+    )
+    .expect("metric should be created")
+});
+
 pub static READ_AHEAD_ACTIVE_TASKS: Lazy<IntGauge> = Lazy::new(|| {
     IntGauge::new(
         "read_ahead_active_tasks",
@@ -1234,6 +1242,9 @@ fn register_custom_metrics() {
     REGISTRY
         .register(Box::new(READ_AHEAD_WASTED_BYTES.clone()))
         .expect("read_ahead_wasted_bytes must be registered");
+    REGISTRY
+        .register(Box::new(TOTAL_READ_AHEAD_ACTIVE_TASKS.clone()))
+        .expect("total_read_ahead_active_tasks must be registered");
     REGISTRY
         .register(Box::new(READ_AHEAD_ACTIVE_TASKS.clone()))
         .expect("read_ahead_active_tasks must be registered");

--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -710,6 +710,24 @@ pub static READ_WITH_AHEAD_DURATION: Lazy<Histogram> = Lazy::new(|| {
     Histogram::with_opts(opts).unwrap()
 });
 
+pub static READ_WITH_AHEAD_DURATION_OF_SEQUENTIAL: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_with_ahead_of_sequential_duration_seconds",
+        "Duration of reads",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
+pub static READ_WITH_AHEAD_DURATION_OF_READ_PLAN: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_with_ahead_of_read_plan_duration_seconds",
+        "Duration of reads",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
 pub static READ_WITH_AHEAD_HIT_DURATION: Lazy<Histogram> = Lazy::new(|| {
     let opts = HistogramOpts::new(
         "read_with_ahead_hit_duration_seconds",
@@ -761,6 +779,22 @@ pub static READ_AHEAD_ACTIVE_TASKS: Lazy<IntGauge> = Lazy::new(|| {
     IntGauge::new(
         "read_ahead_active_tasks",
         "Number of active read-ahead tasks",
+    )
+    .expect("metric should be created")
+});
+
+pub static READ_AHEAD_ACTIVE_TASKS_OF_SEQUENTIAL: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        "read_ahead_active_tasks_of_sequential",
+        "Number of active read-ahead tasks for sequential",
+    )
+    .expect("metric should be created")
+});
+
+pub static READ_AHEAD_ACTIVE_TASKS_OF_READ_PLAN: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::new(
+        "read_ahead_active_tasks_of_read_plan",
+        "Number of active read-ahead tasks for read plan",
     )
     .expect("metric should be created")
 });
@@ -1159,6 +1193,12 @@ fn register_custom_metrics() {
         .register(Box::new(READ_WITH_AHEAD_DURATION.clone()))
         .expect("read_with_ahead_duration must be registered");
     REGISTRY
+        .register(Box::new(READ_WITH_AHEAD_DURATION_OF_SEQUENTIAL.clone()))
+        .expect("read_with_ahead_duration must be registered");
+    REGISTRY
+        .register(Box::new(READ_WITH_AHEAD_DURATION_OF_READ_PLAN.clone()))
+        .expect("read_with_ahead_duration must be registered");
+    REGISTRY
         .register(Box::new(READ_WITH_AHEAD_HIT_DURATION.clone()))
         .expect("read_with_ahead_hit_duration must be registered");
     REGISTRY
@@ -1179,6 +1219,12 @@ fn register_custom_metrics() {
     REGISTRY
         .register(Box::new(READ_AHEAD_ACTIVE_TASKS.clone()))
         .expect("read_ahead_active_tasks must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_ACTIVE_TASKS_OF_SEQUENTIAL.clone()))
+        .expect("read_ahead_active_tasks_of_sequential must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_ACTIVE_TASKS_OF_READ_PLAN.clone()))
+        .expect("read_ahead_active_tasks_of_read_plan must be registered");
     REGISTRY
         .register(Box::new(READ_AHEAD_OPERATION_DURATION.clone()))
         .expect("read_ahead_operation_duration must be registered");

--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -808,6 +808,24 @@ pub static READ_AHEAD_OPERATION_DURATION: Lazy<Histogram> = Lazy::new(|| {
     Histogram::with_opts(opts).unwrap()
 });
 
+pub static READ_AHEAD_OPERATION_DURATION_OF_SEQUENTIAL: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_ahead_operation_of_sequential_duration_seconds",
+        "Duration of read-ahead operations",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
+pub static READ_AHEAD_OPERATION_DURATION_OF_READ_PLAN: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "read_ahead_operation_of_read_plan_duration_seconds",
+        "Duration of read-ahead operations",
+    )
+    .buckets(Vec::from(DEFAULT_BUCKETS));
+    Histogram::with_opts(opts).unwrap()
+});
+
 pub static READ_AHEAD_OPERATION_FAILURE_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     IntCounter::new(
         "read_ahead_operation_failure_count",
@@ -1227,6 +1245,14 @@ fn register_custom_metrics() {
         .expect("read_ahead_active_tasks_of_read_plan must be registered");
     REGISTRY
         .register(Box::new(READ_AHEAD_OPERATION_DURATION.clone()))
+        .expect("read_ahead_operation_duration must be registered");
+    REGISTRY
+        .register(Box::new(
+            READ_AHEAD_OPERATION_DURATION_OF_SEQUENTIAL.clone(),
+        ))
+        .expect("read_ahead_operation_duration must be registered");
+    REGISTRY
+        .register(Box::new(READ_AHEAD_OPERATION_DURATION_OF_READ_PLAN.clone()))
         .expect("read_ahead_operation_duration must be registered");
     REGISTRY
         .register(Box::new(READ_AHEAD_OPERATION_FAILURE_COUNT.clone()))

--- a/riffle-server/src/mini_riffle.rs
+++ b/riffle-server/src/mini_riffle.rs
@@ -194,6 +194,7 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
+            task_id: 0,
         })
         .await?;
     let mut total_partition_len = 0;
@@ -210,6 +211,7 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
+            task_id: 0,
         })
         .await?;
     let xdata = response.from_local();

--- a/riffle-server/src/mini_riffle.rs
+++ b/riffle-server/src/mini_riffle.rs
@@ -193,6 +193,7 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             sequential: false,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
+            localfile_next_read_segments: vec![],
         })
         .await?;
     let mut total_partition_len = 0;
@@ -208,6 +209,7 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             sequential: false,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
+            localfile_next_read_segments: vec![],
         })
         .await?;
     let xdata = response.from_local();

--- a/riffle-server/src/store/local/delegator.rs
+++ b/riffle-server/src/store/local/delegator.rs
@@ -107,11 +107,8 @@ impl LocalDiskDelegator {
             );
         }
         if let Some(options) = config.read_ahead_options.as_ref() {
-            operator_builder = operator_builder.layer(ReadAheadLayer::new(
-                root,
-                options,
-                runtime_manager.localfile_write_runtime.clone(),
-            ));
+            operator_builder =
+                operator_builder.layer(ReadAheadLayer::new(root, options, runtime_manager.clone()));
             info!("Read ahead layer is enabled for disk: {}.", root);
         }
         let io_handler = operator_builder

--- a/riffle-server/src/store/local/delegator.rs
+++ b/riffle-server/src/store/local/delegator.rs
@@ -107,7 +107,11 @@ impl LocalDiskDelegator {
             );
         }
         if let Some(options) = config.read_ahead_options.as_ref() {
-            operator_builder = operator_builder.layer(ReadAheadLayer::new(root, options));
+            operator_builder = operator_builder.layer(ReadAheadLayer::new(
+                root,
+                options,
+                runtime_manager.localfile_write_runtime.clone(),
+            ));
             info!("Read ahead layer is enabled for disk: {}.", root);
         }
         let io_handler = operator_builder

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -320,8 +320,8 @@ impl LocalIO for ReadAheadLayerWrapper {
         };
 
         info!(
-            "Deleted ahead cache for prefix: {} that costs {} millis",
-            prefix, millis
+            "Deleted ahead cache for prefix: {} with {} load_tasks that costs {} millis",
+            prefix, tasks, millis
         );
 
         self.handler.delete(path).await

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -123,7 +123,6 @@ impl ReadAheadLayerWrapper {
         path: &str,
         options: ReadOptions,
     ) -> anyhow::Result<DataBytes, WorkerError> {
-        info!("Ahead options: {:?}", &options.ahead_options);
         let timer = Instant::now();
 
         let abs_path = format!("{}/{}", &self.root, path);

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -331,12 +331,6 @@ struct ReadPlanReadAheadTask {
     processor: ReadPlanReadAheadTaskProcessor,
 }
 
-impl Drop for ReadPlanReadAheadTask {
-    fn drop(&mut self) {
-        self.processor.remove_task(self.uid);
-    }
-}
-
 impl ReadPlanReadAheadTask {
     fn new(
         abs_path: &str,
@@ -627,12 +621,14 @@ mod tests {
             .block_on(layer.read(relative_file_name.as_str(), options));
         assert!(result.is_ok());
         assert_eq!(1, layer.read_plan_load_tasks.len());
+        assert_eq!(1, layer.read_plan_load_processor.task_size());
 
         runtime_manager
             .default_runtime
             .block_on(layer.delete(sub_dirs.as_str()))
             .unwrap();
         assert_eq!(0, layer.read_plan_load_tasks.len());
+        // assert_eq!(0, layer.read_plan_load_processor.task_size());
     }
 
     struct MockHandler;

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -387,7 +387,7 @@ impl ReadPlanReadAheadTask {
         if off < self.read_offset.load(Ordering::Relaxed) as i64 {
             return Ok(());
         }
-        let _timer = READ_AHEAD_OPERATION_DURATION_OF_SEQUENTIAL.start_timer();
+        let _timer = READ_AHEAD_OPERATION_DURATION_OF_READ_PLAN.start_timer();
         let file = self.file.lock();
         do_read_ahead(&file, self.path.as_str(), off as u64, len as u64);
         Ok(())
@@ -485,7 +485,7 @@ impl SequentialReadAheadTask {
         let diff = inner.load_length - off;
         let next_load_bytes = 2 * inner.batch_size as u64;
         if diff > 0 && diff < next_load_bytes {
-            let _timer = READ_AHEAD_OPERATION_DURATION_OF_READ_PLAN.start_timer();
+            let _timer = READ_AHEAD_OPERATION_DURATION_OF_SEQUENTIAL.start_timer();
             let load_len = next_load_bytes;
             do_read_ahead(
                 &inner.file,

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -372,7 +372,7 @@ impl ReadPlanReadAheadTask {
         Ok(task)
     }
 
-    fn do_load(&self, segment: ReadSegment) -> anyhow::Result<()> {
+    async fn do_load(&self, segment: ReadSegment) -> anyhow::Result<()> {
         let off = segment.offset;
         let len = segment.length;
 

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -119,6 +119,7 @@ impl ReadAheadLayerWrapper {
         path: &str,
         options: ReadOptions,
     ) -> anyhow::Result<DataBytes, WorkerError> {
+        info!("Ahead options: {:?}", &options.ahead_options);
         let timer = Instant::now();
 
         let abs_path = format!("{}/{}", &self.root, path);

--- a/riffle-server/src/store/local/io_layer_read_ahead/processor.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead/processor.rs
@@ -71,4 +71,12 @@ impl ReadPlanReadAheadTaskProcessor {
     pub fn remove_task(&self, task_id: u64) {
         self.tasks.remove(&task_id);
     }
+
+    pub fn get_task(&self, uid: u64) -> Option<ReadPlanReadAheadTask> {
+        self.tasks.get(&uid).map(|task| task.clone())
+    }
+
+    pub fn task_size(&self) -> usize {
+        self.tasks.len()
+    }
 }

--- a/riffle-server/src/store/local/io_layer_read_ahead/processor.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead/processor.rs
@@ -1,0 +1,67 @@
+use crate::runtime::manager::RuntimeManager;
+use crate::runtime::RuntimeRef;
+use crate::store::local::io_layer_read_ahead::ReadPlanReadAheadTask;
+use dashmap::DashMap;
+use log::error;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+#[derive(Clone)]
+pub struct ReadPlanReadAheadTaskProcessor {
+    // key: uid
+    tasks: Arc<DashMap<u64, ReadPlanReadAheadTask>>,
+}
+
+impl ReadPlanReadAheadTaskProcessor {
+    pub fn new(runtime_manager: &RuntimeManager, semphore: Arc<Semaphore>) -> Self {
+        let processor = Self {
+            tasks: Arc::new(Default::default()),
+        };
+        Self::loop_process(&processor, runtime_manager, &semphore);
+        processor
+    }
+
+    fn loop_process(
+        processor: &ReadPlanReadAheadTaskProcessor,
+        runtime_manager: &RuntimeManager,
+        semphore: &Arc<Semaphore>,
+    ) {
+        let processor = processor.clone();
+        let semphore = semphore.clone();
+        let external_rt = runtime_manager.dispatch_runtime.clone();
+        let internal_rt = runtime_manager.localfile_write_runtime.clone();
+        external_rt.clone().spawn(async move {
+            loop {
+                let mut tasks = vec![];
+                let view = processor.tasks.deref().clone().into_read_only();
+                for (tid, task) in view.iter() {
+                    tasks.push(task.clone());
+                }
+
+                for task in tasks {
+                    let tid = task.uid;
+                    if let Ok(segment) = task.recv.try_recv() {
+                        let permit = semphore.clone().acquire_owned().await;
+                        internal_rt.spawn(async move {
+                            let _permit = permit;
+                            if let Err(e) = task.do_load(segment) {
+                                error!("Errors on read ahead for task_id: {}. err: {}", tid, e);
+                            }
+                        });
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        });
+    }
+
+    pub fn add_task(&self, task: &ReadPlanReadAheadTask) {
+        self.tasks.insert(task.uid, task.clone());
+    }
+
+    pub fn remove_task(&self, task_id: u64) {
+        self.tasks.remove(&task_id);
+    }
+}

--- a/riffle-server/src/store/local/io_layer_read_ahead/read_plan_tasks.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead/read_plan_tasks.rs
@@ -1,0 +1,84 @@
+use crate::metric::READ_AHEAD_OPERATION_DURATION_OF_READ_PLAN;
+use crate::store::local::io_layer_read_ahead::do_read_ahead;
+use crate::store::local::io_layer_read_ahead::processor::ReadPlanReadAheadTaskProcessor;
+use crate::urpc::command::ReadSegment;
+use parking_lot::Mutex;
+use std::fs::File;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct ReadPlanReadAheadTask {
+    pub uid: u64,
+    file: Arc<Mutex<File>>,
+    read_offset: Arc<AtomicU64>,
+    plan_offset: Arc<AtomicU64>,
+    sender: Arc<async_channel::Sender<ReadSegment>>,
+    pub recv: Arc<async_channel::Receiver<ReadSegment>>,
+    path: Arc<String>,
+
+    processor: ReadPlanReadAheadTaskProcessor,
+}
+
+impl ReadPlanReadAheadTask {
+    pub fn new(
+        abs_path: &str,
+        uid: u64,
+        processor: &ReadPlanReadAheadTaskProcessor,
+    ) -> anyhow::Result<Self> {
+        let (send, recv) = async_channel::unbounded();
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(abs_path)?;
+        let task = Self {
+            uid,
+            file: Arc::new(Mutex::new(file)),
+            read_offset: Arc::new(Default::default()),
+            plan_offset: Arc::new(Default::default()),
+            sender: Arc::new(send),
+            recv: Arc::new(recv),
+            path: Arc::new(abs_path.to_string()),
+            processor: processor.clone(),
+        };
+        processor.add_task(&task);
+        Ok(task)
+    }
+
+    pub async fn do_load(&self, segment: ReadSegment) -> anyhow::Result<()> {
+        let off = segment.offset;
+        let len = segment.length;
+
+        if off < self.read_offset.load(Ordering::Relaxed) as i64 {
+            return Ok(());
+        }
+        let _timer = READ_AHEAD_OPERATION_DURATION_OF_READ_PLAN.start_timer();
+        let file = self.file.lock();
+        do_read_ahead(&file, self.path.as_str(), off as u64, len as u64);
+        Ok(())
+    }
+
+    pub async fn load(
+        &self,
+        next_segments: &Vec<ReadSegment>,
+        now_read_off: u64,
+    ) -> anyhow::Result<()> {
+        self.read_offset.store(now_read_off, Ordering::SeqCst);
+
+        // for plan offset
+        let now_plan_offset = self.plan_offset.load(Ordering::SeqCst);
+        let mut max = now_plan_offset;
+        for next_segment in next_segments {
+            let off = next_segment.offset as u64;
+            if off > now_plan_offset {
+                self.sender.send(next_segment.clone()).await?;
+                max = off;
+            }
+        }
+        self.plan_offset.store(max, Ordering::SeqCst);
+
+        Ok(())
+    }
+}

--- a/riffle-server/src/store/local/io_layer_read_ahead/sequential_tasks.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead/sequential_tasks.rs
@@ -1,0 +1,72 @@
+use crate::metric::READ_AHEAD_OPERATION_DURATION_OF_SEQUENTIAL;
+use crate::store::local::io_layer_read_ahead::do_read_ahead;
+use std::fs::File;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SequentialReadAheadTask {
+    inner: Arc<tokio::sync::Mutex<Inner>>,
+}
+
+struct Inner {
+    absolute_path: String,
+    file: File,
+
+    is_initialized: bool,
+    load_start_offset: u64,
+    load_length: u64,
+
+    batch_size: usize,
+    batch_number: usize,
+}
+
+impl SequentialReadAheadTask {
+    pub fn new(abs_path: &str, batch_size: usize, batch_number: usize) -> anyhow::Result<Self> {
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(abs_path)?;
+        Ok(Self {
+            inner: Arc::new(tokio::sync::Mutex::new(Inner {
+                absolute_path: abs_path.to_string(),
+                file,
+                is_initialized: false,
+                load_start_offset: 0,
+                load_length: 0,
+                batch_size,
+                batch_number,
+            })),
+        })
+    }
+
+    // the return value shows whether the load operation happens
+    pub async fn load(&self, off: u64, len: u64) -> anyhow::Result<bool> {
+        let mut inner = self.inner.lock().await;
+        if !inner.is_initialized && off == 0 {
+            let load_len = (inner.batch_number * inner.batch_size) as u64;
+            do_read_ahead(&inner.file, inner.absolute_path.as_str(), 0, load_len);
+            inner.is_initialized = true;
+            inner.load_length = load_len;
+            return Ok(true);
+        }
+
+        let diff = inner.load_length - off;
+        let next_load_bytes = 2 * inner.batch_size as u64;
+        if diff > 0 && diff < next_load_bytes {
+            let _timer = READ_AHEAD_OPERATION_DURATION_OF_SEQUENTIAL.start_timer();
+            let load_len = next_load_bytes;
+            do_read_ahead(
+                &inner.file,
+                inner.absolute_path.as_str(),
+                inner.load_start_offset + inner.load_length,
+                load_len,
+            );
+            inner.load_length += load_len;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+}

--- a/riffle-server/src/store/localfile.rs
+++ b/riffle-server/src/store/localfile.rs
@@ -487,15 +487,16 @@ impl Store for LocalFileStore {
                 } else {
                     read_options.with_buffer_io()
                 };
-
-                if ctx.sequential {
+                if ctx.sequential || !ctx.localfile_next_read_segments.is_empty() {
                     let ahead = AheadOptions {
-                        sequential: true,
+                        sequential: ctx.sequential,
                         read_batch_number: ctx.read_ahead_batch_number,
                         read_batch_size: ctx.read_ahead_batch_size,
+                        next_read_segments: ctx.localfile_next_read_segments.clone(),
                     };
                     read_options = read_options.with_ahead_options(ahead);
                 }
+                let read_options = read_options.with_task_id(ctx.task_id);
 
                 let future_read = local_disk.read(&data_file_path, read_options);
                 let data = future_read

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -184,6 +184,7 @@ pub struct GetLocalDataRequestV3Command {
     pub(crate) timestamp: i64,
     pub(crate) storage_id: i32,
     pub(crate) next_read_segments: Vec<ReadSegment>,
+    pub(crate) task_id: i64,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -4,6 +4,7 @@ use crate::app_manager::request_context::{
     ReadingIndexViewContext, ReadingOptions, ReadingViewContext, RpcType, WritingViewContext,
 };
 use crate::app_manager::AppManagerRef;
+use crate::config::RpcVersion;
 use crate::constant::StatusCode;
 use crate::metric::URPC_SEND_DATA_TRANSPORT_TIME;
 use crate::store::ResponseDataIndex::Local;
@@ -425,6 +426,14 @@ impl GetLocalDataIndexRequestCommand {
         let application_id = ApplicationId::from(app_id);
         let uid = PartitionUId::new(&application_id, shuffle_id, partition_id);
         let ctx = ReadingIndexViewContext { partition_id: uid };
+
+        let config = app_manager_ref.get_config();
+        let rpc_version = if let Some(c) = &config.urpc_config {
+            c.get_index_rpc_version.clone()
+        } else {
+            RpcVersion::V1
+        };
+        // todo: return the v1/v2 version response by the option
 
         let mut len = 0;
         let command = match app

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -26,6 +26,7 @@ pub enum Command {
     GetMem(GetMemoryDataRequestCommand),
     GetLocalIndex(GetLocalDataIndexRequestCommand),
     GetLocalData(GetLocalDataRequestCommand),
+    GetLocalDataV3(GetLocalDataRequestV3Command),
 }
 
 impl Command {
@@ -35,6 +36,7 @@ impl Command {
             Frame::GetMemoryData(req) => Ok(Command::GetMem(req)),
             Frame::GetLocalDataIndex(req) => Ok(Command::GetLocalIndex(req)),
             Frame::GetLocalData(req) => Ok(Command::GetLocalData(req)),
+            Frame::GetLocalDataV3(req) => Ok(Command::GetLocalDataV3(req)),
             _ => todo!(),
         }
     }
@@ -50,6 +52,7 @@ impl Command {
             Command::GetMem(req) => req.apply(app_manager_ref, conn, shutdown).await?,
             Command::GetLocalIndex(req) => req.apply(app_manager_ref, conn, shutdown).await?,
             Command::GetLocalData(req) => req.apply(app_manager_ref, conn, shutdown).await?,
+            Command::GetLocalDataV3(req) => req.apply(app_manager_ref, conn, shutdown).await?,
             _ => {}
         }
         Ok(())
@@ -168,6 +171,115 @@ pub struct GetLocalDataRequestCommand {
     pub(crate) timestamp: i64,
 }
 
+#[derive(Debug, Default)]
+pub struct GetLocalDataRequestV3Command {
+    pub(crate) request_id: i64,
+    pub(crate) app_id: String,
+    pub(crate) shuffle_id: i32,
+    pub(crate) partition_id: i32,
+    pub(crate) partition_num_per_range: i32,
+    pub(crate) partition_num: i32,
+    pub(crate) offset: i64,
+    pub(crate) length: i32,
+    pub(crate) timestamp: i64,
+    pub(crate) storage_id: i32,
+    pub(crate) next_read_segments: Vec<ReadSegment>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ReadSegment {
+    pub offset: i64,
+    pub length: i64,
+}
+
+impl GetLocalDataRequestV3Command {
+    pub(crate) async fn apply(
+        &self,
+        app_manager_ref: AppManagerRef,
+        conn: &mut Connection,
+        shutdown: &mut Shutdown,
+    ) -> Result<()> {
+        let timer = Instant::now();
+
+        let request_id = self.request_id;
+        let app_id = self.app_id.as_str();
+        let shuffle_id = self.shuffle_id;
+        let partition_id = self.partition_id;
+        let offset = self.offset;
+        let length = self.length;
+        let application_id = ApplicationId::from(app_id);
+        // todo: haven't support multi disk for one partition.
+        let storage_id = self.storage_id;
+
+        let app = app_manager_ref.get_app(&application_id);
+        if app.is_none() {
+            let command = GetLocalDataResponseCommand {
+                request_id,
+                status_code: StatusCode::NO_REGISTER.into(),
+                ret_msg: "No such app in server side".to_string(),
+                data: Default::default(),
+            };
+            let frame = Frame::GetLocalDataResponse(command);
+            conn.write_frame(&frame)
+                .instrument_await("No such app and then fast return")
+                .await?;
+            return Ok(());
+        }
+
+        let app = app.unwrap();
+        let uid = PartitionUId::new(&application_id, shuffle_id, partition_id);
+        let ctx = ReadingViewContext::new(
+            uid,
+            ReadingOptions::FILE_OFFSET_AND_LEN(offset, length as i64),
+            RpcType::URPC,
+        )
+        .with_localfile_next_read_segments(self.next_read_segments.clone());
+        let mut len = 0;
+        let command = match app
+            .select(ctx)
+            .instrument_await(format!("getting local shuffle data for app:{}", &app_id))
+            .await
+        {
+            Err(e) => GetLocalDataResponseCommand {
+                request_id,
+                status_code: StatusCode::INTERNAL_ERROR.into(),
+                ret_msg: format!("Errors on getting file data. err: {:#?}", e),
+                data: Default::default(),
+            },
+            Ok(result) => {
+                if let ResponseData::Local(data) = result {
+                    len = data.data.len();
+                    GetLocalDataResponseCommand {
+                        request_id,
+                        status_code: StatusCode::SUCCESS.into(),
+                        ret_msg: "".to_string(),
+                        data: data.data,
+                    }
+                } else {
+                    GetLocalDataResponseCommand {
+                        request_id,
+                        status_code: StatusCode::INTERNAL_ERROR.into(),
+                        ret_msg: "Incorrect local data type.".to_string(),
+                        data: Default::default(),
+                    }
+                }
+            }
+        };
+
+        let frame = Frame::GetLocalDataResponse(command);
+        conn.write_frame(&frame).await?;
+        info!(
+            "[get_local_data] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}",
+            timer.elapsed().as_millis(),
+            len,
+            app_id,
+            shuffle_id,
+            partition_id,
+        );
+        Ok(())
+    }
+}
+
 impl GetLocalDataRequestCommand {
     pub(crate) async fn apply(
         &self,
@@ -262,6 +374,15 @@ pub struct GetLocalDataIndexResponseCommand {
 }
 
 #[derive(Debug)]
+pub struct GetLocalDataIndexV2ResponseCommand {
+    pub(crate) request_id: i64,
+    pub(crate) status_code: i32,
+    pub(crate) ret_msg: String,
+    pub(crate) data_index: LocalDataIndex,
+    pub(crate) storage_ids: Vec<usize>,
+}
+
+#[derive(Debug)]
 pub struct GetLocalDataIndexRequestCommand {
     pub(crate) request_id: i64,
     pub(crate) app_id: String,
@@ -310,24 +431,27 @@ impl GetLocalDataIndexRequestCommand {
             .instrument_await(format!("listing localfile index for app:{}", &app_id))
             .await
         {
-            Err(err) => GetLocalDataIndexResponseCommand {
+            Err(err) => GetLocalDataIndexV2ResponseCommand {
                 request_id,
                 status_code: StatusCode::INTERNAL_ERROR.into(),
                 ret_msg: format!("Errors on listing local index. err: {:#?}", err),
                 data_index: Default::default(),
+                storage_ids: vec![],
             },
             Ok(index) => {
                 let Local(result) = index;
                 len = result.index_data.len();
-                GetLocalDataIndexResponseCommand {
+                GetLocalDataIndexV2ResponseCommand {
                     request_id,
                     status_code: StatusCode::SUCCESS.into(),
                     ret_msg: "".to_string(),
                     data_index: result,
+                    // todo: haven't support multi disk for one partition.
+                    storage_ids: vec![0],
                 }
             }
         };
-        let frame = Frame::GetLocalDataIndexResponse(command);
+        let frame = Frame::GetLocalDataIndexV2Response(command);
         conn.write_frame(&frame).await?;
         info!(
             "[get_local_index] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}",

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -50,8 +50,8 @@ pub enum MessageType {
     GetMemoryDataResponse = 16,
 
     GetLocalDataIndex = 4,
-    GetLocalDataIndexV2 = 23,
     GetLocalDataIndexResponse = 14,
+    GetLocalDataIndexV2Response = 23,
 
     GetLocalData = 5,
     GetLocalDataV3 = 25,
@@ -161,7 +161,7 @@ impl Frame {
 
                 // header
                 write_buf.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + 8);
-                write_buf.put_u8(MessageType::GetLocalDataIndexResponse as u8);
+                write_buf.put_u8(MessageType::GetLocalDataIndexV2Response as u8);
                 write_buf.put_i32(index_bytes.len() as i32);
 
                 // partial content with general response info
@@ -523,9 +523,6 @@ impl Frame {
             MessageType::GetLocalDataIndex => {
                 let command = Frame::parse_to_get_localfile_index_command(src)?;
                 return Ok(Frame::GetLocalDataIndex(command));
-            }
-            MessageType::GetLocalDataIndexV2 => {
-                let command = Frame::parse_to_get_localfile_index_command(src)?;
             }
             MessageType::GetMemoryData => {
                 let command = Frame::parse_to_get_memory_data_command(src)?;

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -180,18 +180,17 @@ impl Frame {
                 // write the data length
                 write_buf.put_i64(data_file_len);
 
-                stream.write_all(&write_buf.split()).await?;
-
-                // write the all bytes
-                let data = index_bytes.freeze();
-                stream.write_all(&data).await?;
-
                 // write the storage ids
                 write_buf.put_i32(resp.storage_ids.len() as i32);
                 for storage_id in &resp.storage_ids {
                     write_buf.put_i32(*storage_id as i32);
                 }
+
                 stream.write_all(&write_buf.split()).await?;
+
+                // write the all bytes
+                let data = index_bytes.freeze();
+                stream.write_all(&data).await?;
 
                 Ok(())
             }

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -164,7 +164,7 @@ impl Frame {
                 let data_file_len = resp.data_index.data_file_len;
 
                 // header
-                write_buf.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + 8);
+                write_buf.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + 8 + 4 * resp.storage_ids.len() as i32);
                 write_buf.put_u8(MessageType::GetLocalDataIndexV2Response as u8);
                 write_buf.put_i32(index_bytes.len() as i32);
 

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -164,7 +164,9 @@ impl Frame {
                 let data_file_len = resp.data_index.data_file_len;
 
                 // header
-                write_buf.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + 8 + 4 * resp.storage_ids.len() as i32);
+                write_buf.put_i32(
+                    msg_bytes.len() as i32 + 8 + 4 + 4 + 8 + 4 * resp.storage_ids.len() as i32,
+                );
                 write_buf.put_u8(MessageType::GetLocalDataIndexV2Response as u8);
                 write_buf.put_i32(index_bytes.len() as i32);
 

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -342,6 +342,7 @@ impl Frame {
                 length: get_i64(src)?,
             });
         }
+        let task_id = get_i64(src)?;
 
         Ok(GetLocalDataRequestV3Command {
             request_id,
@@ -355,6 +356,7 @@ impl Frame {
             timestamp,
             storage_id,
             next_read_segments: segments,
+            task_id,
         })
     }
 

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -164,8 +164,9 @@ impl Frame {
                 let data_file_len = resp.data_index.data_file_len;
 
                 // header
+                // compared with the v1 version, add the extra [4 + 4 * storage_ids.len()]
                 write_buf.put_i32(
-                    msg_bytes.len() as i32 + 8 + 4 + 4 + 8 + 4 * resp.storage_ids.len() as i32,
+                    msg_bytes.len() as i32 + 8 + 4 + 4 + 8 + 4 + 4 * resp.storage_ids.len() as i32,
                 );
                 write_buf.put_u8(MessageType::GetLocalDataIndexV2Response as u8);
                 write_buf.put_i32(index_bytes.len() as i32);


### PR DESCRIPTION
# Motivation

In the first phase of read-ahead (#411), the strategy has been validated, showing an improvement of over 15% in shuffle read speed. However, this benefit currently applies only to normal partitions that follow the sequential reading pattern.

For very large partitions, the reading mode may become non-sequential due to AQE skew-join optimizations. In such cases, predicting the next read position and length is challenging.

This PR enables the read-plan strategy introduced in [#2603](https://github.com/apache/uniffle/pull/2603), extending the optimization to handle these scenarios.

# Under the hood of this strategy

This PR does not modify the existing sequential read-ahead strategy. Instead, it introduces a new strategy called read-plan read-ahead tasks. In this approach, the read plan is provided by the client side, so this PR also adds support for a newer version of URPC (gRPC is not yet implemented but should be supported in the future).

Compared with the sequential strategy, synchronizing do_read_ahead operations is more challenging here: the segments are small, and the execution overhead becomes significant. To address this, we introduce a dedicated, shareable processor that leverages a semaphore to control concurrency and a shared thread pool to prevent system overload.

# How to enable this

This PR depends on the uniffle side change, but this is compatible with the legacy uniffle client. If you want to enable this feature, follow the next steps

1. Upgrade the uniffle client with the patch of https://github.com/apache/uniffle/pull/2603 . and with the following spark configs

```
spark.rss.riffle.readAheadEnabled=true
spark.rss.client.read.nextReadSegmentsReportEnabled=true
```

2. With the following riffle config options

```
[localfile_store.read_ahead_options]
batch_size = "15M"
batch_number = 4
read_plan_enable = true
read_plan_concurrency = 1000

[urpc_config]
get_index_rpc_version = "V2"
```