### PR TITLE
fix: Potential duplicate `partition_stats` report bound by the same task_attempt_id

### DIFF
--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -62,7 +62,7 @@ pub struct App {
     // key: shuffle_id, val: shuffle's all block_ids bitmap
     block_id_manager: Arc<Box<dyn BlockIdManager>>,
 
-    partition_stats_manager: Arc<PartitionStatsManager>,
+    partition_stats_manager: PartitionStatsManager,
 
     // key: (shuffle_id, partition_id)
     partition_meta_infos: DDashMap<(i32, i32), PartitionMeta>,
@@ -156,7 +156,7 @@ impl App {
             partition_split_threshold,
             reconf_manager: reconf_manager.clone(),
             partition_split_triggered: AtomicBool::new(false),
-            partition_stats_manager: Arc::new(PartitionStatsManager::new()),
+            partition_stats_manager: PartitionStatsManager::new(),
         }
     }
 
@@ -423,7 +423,7 @@ impl App {
         self.heartbeat()?;
 
         // report partition records
-        self.partition_stats_manager.report(&ctx)?;
+        self.partition_stats_manager.add(&ctx)?;
 
         // report block_ids
         let number = self.block_id_manager.report_multi_block_ids(ctx).await?;

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -2,7 +2,7 @@ use crate::app_manager::app_configs::AppConfigOptions;
 use crate::app_manager::partition_identifier::PartitionUId;
 use crate::app_manager::purge_event::PurgeReason;
 use crate::id_layout::IdLayout;
-use crate::partition_stats::{PartitionStats, TaskAttemptIdToRecordRef};
+use crate::partition_stats::{PartitionStats, TaskToRecordStatRef};
 use crate::store::Block;
 use crate::urpc::command::ReadSegment;
 use bytes::Bytes;


### PR DESCRIPTION
If `reportShuffleResult` is retried at the RPC layer, the same request may be issued multiple times. This PR ensures that each record is processed only once.