### PR TITLE
feat: Add `isEnd` to indicate EOF on getting memory data

### DIFF
--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -469,6 +469,12 @@ pub struct Config {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct UrpcConfig {
     pub get_index_rpc_version: RpcVersion,
+    #[serde(default = "as_default_get_memory_rpc_version")]
+    pub get_memory_rpc_version: RpcVersion,
+}
+
+fn as_default_get_memory_rpc_version() -> RpcVersion {
+    RpcVersion::V1
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/riffle-server/src/grpc/protobuf/uniffle.proto
+++ b/riffle-server/src/grpc/protobuf/uniffle.proto
@@ -103,6 +103,7 @@ message GetMemoryShuffleDataResponse {
   bytes data = 2;
   StatusCode status = 3;
   string retMsg = 4;
+  bool is_end = 5;
 }
 
 message GetLocalShuffleIndexRequest {

--- a/riffle-server/src/grpc/protobuf/uniffle.proto
+++ b/riffle-server/src/grpc/protobuf/uniffle.proto
@@ -103,7 +103,7 @@ message GetMemoryShuffleDataResponse {
   bytes data = 2;
   StatusCode status = 3;
   string retMsg = 4;
-  bool is_end = 5;
+  google.protobuf.BoolValue is_end = 5;
 }
 
 message GetLocalShuffleIndexRequest {

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -651,6 +651,7 @@ impl ShuffleServer for DefaultShuffleServer {
                 data: Default::default(),
                 status: StatusCode::NO_REGISTER.into(),
                 ret_msg: "No such app in this shuffle server".to_string(),
+                is_end: false,
             }));
         }
 
@@ -686,6 +687,7 @@ impl ShuffleServer for DefaultShuffleServer {
                 data: Default::default(),
                 status: StatusCode::INTERNAL_ERROR.into(),
                 ret_msg: format!("{:?}", error_msg),
+                is_end: false,
             }));
         }
 
@@ -705,6 +707,7 @@ impl ShuffleServer for DefaultShuffleServer {
             data: bytes,
             status: StatusCode::SUCCESS.into(),
             ret_msg: "".to_string(),
+            is_end: data.is_end,
         }))
     }
 

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -651,7 +651,7 @@ impl ShuffleServer for DefaultShuffleServer {
                 data: Default::default(),
                 status: StatusCode::NO_REGISTER.into(),
                 ret_msg: "No such app in this shuffle server".to_string(),
-                is_end: false,
+                is_end: None,
             }));
         }
 
@@ -687,7 +687,7 @@ impl ShuffleServer for DefaultShuffleServer {
                 data: Default::default(),
                 status: StatusCode::INTERNAL_ERROR.into(),
                 ret_msg: format!("{:?}", error_msg),
-                is_end: false,
+                is_end: None,
             }));
         }
 
@@ -707,7 +707,7 @@ impl ShuffleServer for DefaultShuffleServer {
             data: bytes,
             status: StatusCode::SUCCESS.into(),
             ret_msg: "".to_string(),
-            is_end: data.is_end,
+            is_end: Some(data.is_end),
         }))
     }
 

--- a/riffle-server/src/store/mod.rs
+++ b/riffle-server/src/store/mod.rs
@@ -135,6 +135,7 @@ pub struct PartitionedLocalData {
 pub struct PartitionedMemoryData {
     pub shuffle_data_block_segments: Vec<DataSegment>,
     pub data: DataBytes,
+    pub is_end: bool,
 }
 
 #[derive(Debug)]

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -325,10 +325,10 @@ impl Frame {
                     write_buf.put_i64(segment.crc);
                     write_buf.put_i64(segment.task_attempt_id);
                 }
-                stream.write_all(&write_buf.split()).await?;
-
                 // add is_end flag
                 write_buf.put_u8(mem_data.is_end as u8);
+
+                stream.write_all(&write_buf.split()).await?;
 
                 // data_bytes
                 for composed_byte in data_bytes_wrapper.always_composed().iter() {

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -327,13 +327,13 @@ impl Frame {
                 }
                 stream.write_all(&write_buf.split()).await?;
 
+                // add is_end flag
+                write_buf.put_u8(mem_data.is_end as u8);
+
                 // data_bytes
                 for composed_byte in data_bytes_wrapper.always_composed().iter() {
                     stream.write_all(&composed_byte).await?;
                 }
-
-                // add is_end flag
-                write_buf.put_u8(mem_data.is_end as u8);
 
                 Ok(())
             }

--- a/riffle-server/src/urpc/frame.rs
+++ b/riffle-server/src/urpc/frame.rs
@@ -49,6 +49,7 @@ pub enum MessageType {
     SendShuffleData = 3,
     GetMemoryData = 6,
     GetMemoryDataResponse = 16,
+    GetMemoryDataV2Response = 26,
 
     GetLocalDataIndex = 4,
     GetLocalDataIndexResponse = 14,
@@ -304,7 +305,7 @@ impl Frame {
                 // header
                 // compared with v1, only includes the extra bytes to store is_end flag
                 write_buf.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + segments_encode_len + 1);
-                write_buf.put_u8(MessageType::GetMemoryDataResponse as u8);
+                write_buf.put_u8(MessageType::GetMemoryDataV2Response as u8);
                 write_buf.put_i32(data_bytes_len);
 
                 // partial content with general response info
@@ -313,9 +314,6 @@ impl Frame {
 
                 write_buf.put_i32(msg_bytes.len() as i32);
                 write_buf.put(msg_bytes);
-
-                // add is_end flag
-                write_buf.put_u8(mem_data.is_end as u8);
 
                 // write segment
                 write_buf.put_i32(segments.len() as i32);
@@ -333,6 +331,10 @@ impl Frame {
                 for composed_byte in data_bytes_wrapper.always_composed().iter() {
                     stream.write_all(&composed_byte).await?;
                 }
+
+                // add is_end flag
+                write_buf.put_u8(mem_data.is_end as u8);
+
                 Ok(())
             }
             Frame::RpcResponse(resp) => {


### PR DESCRIPTION
 This PR is the riffle server side implementation for the [uniffle PR](https://github.com/apache/uniffle/pull/2685)

### What changes were proposed in this pull request?

This PR introduces an additional `isEnd` flag to indicate whether the end of the in-memory data has been reached.
For simplicity, this flag does not guarantee precise end-of-data detection; the client should still rely on its existing logic to determine completion. However, this flag should be sufficient to cover most cases.

Attention that after this PR, the upgrade should first be performed on the client side, followed by upgrading the shuffle servers.

### Why are the changes needed?

for #2684 .

As we all know, reading memory data is based on `last_block_id`, which determines the starting position. However, when duplicate `block_id`s appear in the sequence, the client may read duplicate blocks. This is acceptable because the client relies on the `processed_block_ids` mechanism to handle duplicates.

The issue arises when a duplicate block appears at the end of the memory data sequence. In this case, the client keeps receiving the same last block repeatedly, causing the read operation to run indefinitely, as illustrated below.

First round of blockIds:
```
703702683883796
844440172239124
703702683884548
985177660594452
1125915148949780  (duplicate)
844440172239876
985177660595204
1125915148950532
1266652637305860
985177660594452  
1125915148949780  (duplicate)
```

Second round of blockIds:
```
844440172239876
985177660595204
1125915148950532
1266652637305860
985177660594452 
1125915148949780  (duplicate)
```

At this point, the duplicated last blocks cause the client to repeatedly read the same tail of the sequence, resulting in an infinite loop.
