### PR TITLE
feat: Use `spark.rss.riffle.getMemoryDataUrpcVersion` for client to control compatible urpc version

### DIFF
--- a/riffle-server/src/app_manager.rs
+++ b/riffle-server/src/app_manager.rs
@@ -446,6 +446,7 @@ pub(crate) mod test {
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             client_configs: Default::default(),
+            get_memory_data_urpc_version: Default::default(),
         };
         app_manager_ref
             .register(raw_app_id.to_string(), shuffle_id, app_options)

--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 
 pub struct App {
     pub app_id: String,
-    app_config_options: AppConfigOptions,
+    pub app_config_options: AppConfigOptions,
     latest_heartbeat_time: AtomicU64,
     store: Arc<HybridStore>,
 

--- a/riffle-server/src/app_manager/app_configs.rs
+++ b/riffle-server/src/app_manager/app_configs.rs
@@ -1,9 +1,10 @@
 use crate::app_manager::request_context::PurgeDataContext;
 use crate::client_configs::{
-    ClientConfigOption, ClientRssConf, HDFS_CLIENT_EAGER_LOADING_ENABLED_OPTION,
-    READ_AHEAD_BATCH_NUMBER, READ_AHEAD_BATCH_SIZE, READ_AHEAD_ENABLED_OPTION,
-    SENDFILE_ENABLED_OPTION,
+    ClientConfigOption, ClientRssConf, GET_MEMORY_DATA_URPC_VERSION,
+    HDFS_CLIENT_EAGER_LOADING_ENABLED_OPTION, READ_AHEAD_BATCH_NUMBER, READ_AHEAD_BATCH_SIZE,
+    READ_AHEAD_ENABLED_OPTION, SENDFILE_ENABLED_OPTION,
 };
+use crate::config::RpcVersion;
 use crate::grpc::protobuf::uniffle::RemoteStorage;
 use std::collections::HashMap;
 use std::fmt;
@@ -29,6 +30,9 @@ pub struct AppConfigOptions {
     pub read_ahead_batch_number: Option<usize>,
     pub read_ahead_batch_size: Option<usize>,
     pub client_configs: ClientRssConf,
+
+    // the urpc endpoint version
+    pub get_memory_data_urpc_version: RpcVersion,
 }
 
 impl AppConfigOptions {
@@ -48,6 +52,9 @@ impl AppConfigOptions {
             read_ahead_batch_size: rss_config
                 .get_byte_size(&READ_AHEAD_BATCH_SIZE)
                 .map(|x| x as usize),
+            get_memory_data_urpc_version: rss_config
+                .get(&GET_MEMORY_DATA_URPC_VERSION)
+                .unwrap_or(RpcVersion::V1),
             client_configs: rss_config,
         }
     }
@@ -64,6 +71,7 @@ impl Default for AppConfigOptions {
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             client_configs: Default::default(),
+            get_memory_data_urpc_version: RpcVersion::V1,
         }
     }
 }

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct MemoryStoreConfig {
@@ -469,8 +470,6 @@ pub struct Config {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct UrpcConfig {
     pub get_index_rpc_version: RpcVersion,
-    #[serde(default = "as_default_get_memory_rpc_version")]
-    pub get_memory_rpc_version: RpcVersion,
 }
 
 fn as_default_get_memory_rpc_version() -> RpcVersion {
@@ -487,6 +486,19 @@ pub enum RpcVersion {
 impl Default for RpcVersion {
     fn default() -> Self {
         RpcVersion::V1
+    }
+}
+
+impl FromStr for RpcVersion {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "V1" => Ok(RpcVersion::V1),
+            "V2" => Ok(RpcVersion::V2),
+            "V3" => Ok(RpcVersion::V3),
+            _ => Ok(RpcVersion::V1),
+        }
     }
 }
 

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -125,11 +125,7 @@ impl GetMemoryDataRequestCommand {
         let result = app.select(ctx).await;
         let mut read_length = 0;
 
-        let rpc_version = if let Some(config) = &app_manager_ref.get_config().urpc_config {
-            config.get_memory_rpc_version.clone()
-        } else {
-            RpcVersion::V1
-        };
+        let rpc_version = &app.app_config_options.get_memory_data_urpc_version;
         match rpc_version {
             RpcVersion::V1 => {
                 let response = match result {
@@ -176,12 +172,13 @@ impl GetMemoryDataRequestCommand {
         }
 
         info!(
-            "[get_memory_data] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}",
+            "[get_memory_data][{:?}] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}.",
+            rpc_version,
             timer.elapsed().as_millis(),
             read_length,
             app_id,
             shuffle_id,
-            partition_id
+            partition_id,
         );
         Ok(())
     }


### PR DESCRIPTION
This is the follow-up PR to #527, introducing a client-side option that controls the server-side uRPC behavior when fetching memory data. This allows the scenario where the riffle-servers are upgraded first, followed by upgrading the Uniffle client.

Without this client option, the riffle-server will return the legacy uRPC protocol for `getMemoryData`. Once the client enables this option, the server will detect it and switch to the latest uRPC protocol.