### PR TITLE
feat: Trigger partition split when storage is unhealthy

### DIFF
--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -348,8 +348,6 @@ impl App {
         let app_id = &ctx.uid.app_id;
         let shuffle_id = &ctx.uid.shuffle_id;
 
-        let mut partition_split_candidates = HashSet::new();
-
         if self
             .app_config_options
             .client_configs
@@ -364,6 +362,7 @@ impl App {
             return Err(WorkerError::WRITE_LIMITED_BY_STORAGE_STATE);
         }
 
+        let mut partition_split_candidates = HashSet::new();
         if self.partition_limit_enable || self.partition_split_enable {
             let partition_limit_threshold = (self.memory_capacity as f64
                 * self.partition_limit_mem_backpressure_ratio.get())

--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -511,3 +511,102 @@ impl App {
         self.total_resident_data_size.load(SeqCst)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::app_manager::app::App;
+    use crate::app_manager::app_configs::{AppConfigOptions, DataDistribution};
+    use crate::app_manager::application_identifier::ApplicationId;
+    use crate::app_manager::partition_identifier::PartitionUId;
+    use crate::app_manager::request_context::RequireBufferContext;
+    use crate::client_configs::{ClientRssConf, STORAGE_CAPACITY_PARTITION_SPLIT_ENABLED};
+    use crate::config::StorageType;
+    use crate::config::StorageType::LOCALFILE;
+    use crate::config_reconfigure::ReconfigurableConfManager;
+    use crate::error::WorkerError;
+    use crate::runtime::manager::RuntimeManager;
+    use crate::runtime::{Builder, Runtime};
+    use crate::store::spill::spill_test::mock::MockStore;
+    use crate::store::spill::spill_test::tests::create_hybrid_store;
+    use libc::connect;
+    use log::info;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tokio::runtime;
+
+    #[test]
+    fn partition_split_by_storage() -> anyhow::Result<()> {
+        let app_id = ApplicationId::YARN(1, 1, 1);
+
+        let mut hmap = HashMap::new();
+        hmap.insert(
+            "spark.rss.riffle.storageCapacityPartitionSplitEnabled".to_string(),
+            "true".to_string(),
+        );
+        let conf = ClientRssConf::from(hmap);
+        let options = AppConfigOptions::new(DataDistribution::NORMAL, 1, None, conf);
+
+        // server configs
+        let temp_dir = tempdir::TempDir::new("partition_split_by_storage").unwrap();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+        info!("init local file path: {}", &temp_path);
+
+        let mut config = crate::store::spill::spill_test::tests::create_multi_level_config(
+            StorageType::MEMORY_LOCALFILE,
+            1,
+            "1M".to_string(),
+            temp_path,
+        );
+        let reconf_manager = ReconfigurableConfManager::new(&config, None).unwrap();
+
+        // mock storage
+        let healthy_tag = Arc::new(AtomicBool::new(true));
+        let warm = MockStore::new(LOCALFILE, &healthy_tag, None, None);
+        let hybrid_storage = create_hybrid_store(&config, &warm, None, &reconf_manager);
+
+        let runtime_manager = RuntimeManager::from(Default::default());
+        let app = App::from(
+            app_id.to_string(),
+            options,
+            hybrid_storage.clone(),
+            runtime_manager,
+            &config,
+            &reconf_manager,
+        );
+
+        let runtime = Builder::default()
+            .worker_threads(1)
+            .thread_name("test")
+            .enable_all()
+            .build()?;
+
+        // case1: legal
+        let ctx = RequireBufferContext {
+            uid: PartitionUId {
+                app_id: app_id.clone(),
+                shuffle_id: 1,
+                partition_id: 1,
+            },
+            size: 10,
+            partition_ids: vec![0, 1, 2],
+        };
+        runtime
+            .block_on(async { app.require_buffer(ctx.clone()).await })
+            .unwrap();
+
+        // case2: illegal
+        healthy_tag.store(false, Ordering::SeqCst);
+
+        match runtime.block_on(async { app.require_buffer(ctx.clone()).await }) {
+            Err(WorkerError::WRITE_LIMITED_BY_STORAGE_STATE) => {
+                // pass
+            }
+            _ => {
+                panic!("Should throw exception")
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/riffle-server/src/client_configs.rs
+++ b/riffle-server/src/client_configs.rs
@@ -41,6 +41,13 @@ pub static GET_MEMORY_DATA_URPC_VERSION: Lazy<ClientConfigOption<RpcVersion>> = 
         .with_description("the urpc version of getMemoryData")
 });
 
+pub static STORAGE_CAPACITY_PARTITION_SPLIT_ENABLED: Lazy<ClientConfigOption<bool>> =
+    Lazy::new(|| {
+        ClientConfigOption::key("spark.rss.riffle.storageCapacityPartitionSplitEnabled")
+            .default_value(false)
+            .with_description("whether to trigger partition split by the storage capacity")
+    });
+
 #[derive(Debug, Clone, Default)]
 pub struct ClientRssConf {
     properties: HashMap<String, String>,

--- a/riffle-server/src/constant.rs
+++ b/riffle-server/src/constant.rs
@@ -13,6 +13,9 @@ pub enum StatusCode {
     ACCESS_DENIED = 8,
     INVALID_REQUEST = 9,
     NO_BUFFER_FOR_HUGE_PARTITION = 10,
+    // to indicate shuffle-writing not retry!
+    // todo: we should introduce the dedicated status code to indicate this
+    EXCEED_HUGE_PARTITION_HARD_LIMIT = 12,
 }
 
 impl Into<i32> for StatusCode {

--- a/riffle-server/src/error.rs
+++ b/riffle-server/src/error.rs
@@ -55,6 +55,9 @@ pub enum WorkerError {
     #[error("The memory usage is limited by huge partition mechanism")]
     MEMORY_USAGE_LIMITED_BY_HUGE_PARTITION,
 
+    #[error("shuffle writing is limited due to the unhealthy storage state")]
+    WRITE_LIMITED_BY_STORAGE_STATE,
+
     #[error("Http request failed. {0}")]
     HTTP_SERVICE_ERROR(String),
 

--- a/riffle-server/src/grpc/service.rs
+++ b/riffle-server/src/grpc/service.rs
@@ -925,6 +925,12 @@ impl ShuffleServer for DefaultShuffleServer {
                 "".to_string(),
                 vec![],
             ),
+            Err(WorkerError::WRITE_LIMITED_BY_STORAGE_STATE) => (
+                StatusCode::EXCEED_HUGE_PARTITION_HARD_LIMIT,
+                -1i64,
+                "".to_string(),
+                vec![],
+            ),
             Err(err) => (StatusCode::NO_BUFFER, -1i64, format!("{:?}", err), vec![]),
         };
 

--- a/riffle-server/src/store/spill/mod.rs
+++ b/riffle-server/src/store/spill/mod.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 pub mod hierarchy_event_bus;
 mod metrics;
-mod spill_test;
+pub mod spill_test;
 pub mod storage_flush_handler;
 pub mod storage_select_handler;
 

--- a/riffle-server/src/store/spill/spill_test.rs
+++ b/riffle-server/src/store/spill/spill_test.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::app_manager::app::App;
     use crate::app_manager::application_identifier::ApplicationId;
     use crate::app_manager::partition_identifier::PartitionUId;
@@ -33,7 +33,7 @@ mod tests {
         assert_eq!("HDFS", format!("{:?}", store_type));
     }
 
-    fn create_multi_level_config(
+    pub fn create_multi_level_config(
         store_type: StorageType,
         grpc_port: i32,
         capacity: String,
@@ -60,7 +60,7 @@ mod tests {
         toml::from_str(toml_str.as_str()).unwrap()
     }
 
-    fn create_hybrid_store(
+    pub fn create_hybrid_store(
         config: &Config,
         warm: &MockStore,
         cold: Option<&MockStore>,
@@ -477,7 +477,7 @@ mod tests {
     }
 }
 
-mod mock {
+pub mod mock {
     use crate::app_manager::request_context::{
         PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, RegisterAppContext,
         ReleaseTicketContext, RequireBufferContext, WritingViewContext,
@@ -496,7 +496,7 @@ mod mock {
     use std::time::Duration;
 
     #[derive(Clone)]
-    pub(crate) struct MockStore {
+    pub struct MockStore {
         pub(crate) inner: Arc<Inner>,
     }
 


### PR DESCRIPTION
This PR is to trigger partition split on requiring buffer by client side when the storage is unhealthy (like corrupted or insufficient capacity). And that's an experimental feature so that will be disabled by default. client could activate this by the options of `spark.rss.riffle.storageCapacityPartitionSplitEnabled=true`