### PR TITLE
feat: Quick start to build the riffle cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,32 @@ dispatch_thread_num = 10
  
 </details>
 
+## Quick Start with Docker
+
+The fastest way to get started with Riffle is using Docker Compose. This will set up a complete testing environment with Uniffle Coordinator, Riffle Servers, and Spark.
+
+```bash
+cd dev/integration
+docker-compose up riffle-dev
+
+# run Spark SQL with Riffle(Uniffle is enabled by default) and then you can open the spark web UI. 
+./bin/spark-sql --master local[1] -e "SELECT 1"
+
+# shutdown
+docker-compose down
+
+# Remove all volumes as well
+docker-compose down -v
+
+# or rebuild while starting
+docker-compose up --build riffle-dev
+```
+
+**Available Endpoints:**
+- Uniffle Coordinator Web UI: http://localhost:19995
+- Riffle Server 1 Metrics: http://localhost:19998/metrics
+- Riffle Server 2 Metrics: http://localhost:19999/metrics
+
 ## Build
 
 `cargo build --release`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ The fastest way to get started with Riffle is using Docker Compose. This will se
 
 ```bash
 cd dev/integration
-docker-compose up riffle-dev
+docker-compose up -d riffle-dev
+
+# In another terminal, enter the container
+docker-compose exec riffle-dev /bin/bash
 
 # run Spark SQL with Riffle(Uniffle is enabled by default) and then you can open the spark web UI. 
 ./bin/spark-sql --master local[1] -e "SELECT 1"
@@ -107,6 +110,17 @@ docker-compose down -v
 
 # or rebuild while starting
 docker-compose up --build riffle-dev
+```
+
+If you want to connect this riffle cluster for your external spark jobs, you could specify the following spark configs.
+```
+spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
+spark.rss.coordinator.quorum localhost:21000
+spark.rss.storage.type MEMORY_LOCALFILE
+spark.serializer org.apache.spark.serializer.KryoSerializer
+spark.rss.client.assignment.shuffle.nodes.max 1
+spark.rss.dynamicClientConf.enabled false
+spark.rss.client.type GRPC
 ```
 
 **Available Endpoints:**

--- a/dev/integration/docker-compose.yml
+++ b/dev/integration/docker-compose.yml
@@ -1,12 +1,37 @@
 version: "3"
 
 services:
-  spark-sql-test:
+  # Service for running full tests (default)
+  riffle-test:
     build:
       context: .
+    container_name: riffle-test
     volumes:
       - ~/.cargo/git:/root/.cargo/git:rw
       - ~/.cargo/registry:/root/.cargo/registry:rw
       - ./../../:/riffle:rw
       - ./../../target-docker:/riffle/target:rw
     # endpoint.sh is set as ENTRYPOINT in Dockerfile, so no command needed
+    # This will run the tests by default
+
+  # Service for development - skip tests and enter bash
+  riffle-dev:
+    build:
+      context: .
+    container_name: riffle-dev
+    stdin_open: true  # equivalent to -i
+    tty: true         # equivalent to -t
+    volumes:
+      - ~/.cargo/git:/root/.cargo/git:rw
+      - ~/.cargo/registry:/root/.cargo/registry:rw
+      - ./../../:/riffle:rw
+      - ./../../target-docker:/riffle/target:rw
+    command: skip-tests  # Pass argument to skip tests and enter bash
+    ports:
+      - "19995:19995"  # Uniffle Coordinator Web UI
+      - "21000:21000"  # Uniffle Coordinator RPC
+      - "19998:19998"  # Riffle Server 1 (http port)
+      - "21100:21100"  # Riffle Server 1 (grpc port)
+      - "19999:19999"  # Riffle Server 2 (http port)
+      - "21101:21101"  # Riffle Server 2 (grpc port)
+      - "4040:4040"    # Spark UI (if needed)

--- a/dev/integration/endpoint.sh
+++ b/dev/integration/endpoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Check if we should skip tests
+SKIP_TESTS=${1:-false}
+
 # Source environment variables
 source ~/.bashrc
 
@@ -105,6 +108,19 @@ if curl -f http://localhost:19999/metrics >/dev/null 2>&1; then
     echo_info "Riffle Server 2 is running"
 else
     echo_warn "Riffle Server 2 metrics not ready"
+fi
+
+# Check if we should skip tests
+if [ "$SKIP_TESTS" = "true" ] || [ "$SKIP_TESTS" = "skip-tests" ]; then
+    echo_info "==========================================="
+    echo_info "Tests skipped. All services are running:"
+    echo_info "  - Uniffle Coordinator: http://localhost:19995"
+    echo_info "  - Riffle Server 1: http://localhost:19998"
+    echo_info "  - Riffle Server 2: http://localhost:19999"
+    echo_info "  - Spark Home: ${SPARK_HOME}"
+    echo_info "==========================================="
+    echo_info "Entering interactive bash shell..."
+    exec /bin/bash
 fi
 
 # Run Spark SQL Integration Test

--- a/dev/integration/endpoint.sh
+++ b/dev/integration/endpoint.sh
@@ -119,8 +119,15 @@ if [ "$SKIP_TESTS" = "true" ] || [ "$SKIP_TESTS" = "skip-tests" ]; then
     echo_info "  - Riffle Server 2: http://localhost:19999"
     echo_info "  - Spark Home: ${SPARK_HOME}"
     echo_info "==========================================="
-    echo_info "Entering interactive bash shell..."
-    exec /bin/bash
+    echo_info "Container is running. To enter bash shell, run:"
+    echo_info "    docker exec -it riffle-dev /bin/bash"
+    echo_info ""
+    echo_info "Or if using docker-compose:"
+    echo_info "    docker-compose exec riffle-dev /bin/bash"
+    echo_info "==========================================="
+    
+    # Keep the container running
+    tail -f /dev/null
 fi
 
 # Run Spark SQL Integration Test


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Docker Compose-based local dev/test environment (Coordinator + Riffle servers + Spark), a startup script with optional test skipping, and README quick start/configuration docs.
> 
> - **Docs**
>   - Add Docker-based quick start in `README.md`, including Spark configs and exposed endpoints.
> - **Integration/Dev Environment**
>   - Introduce `dev/integration/docker-compose.yml` with two services:
>     - `riffle-test` (runs full tests by default)
>     - `riffle-dev` (interactive; `skip-tests` command; mapped ports for Coordinator, Riffle servers, Spark UI)
>   - Add `dev/integration/endpoint.sh` to orchestrate services:
>     - Starts Uniffle Coordinator and two Riffle servers, verifies `/metrics` readiness
>     - Supports skipping tests and keeping container alive
>     - Runs Spark SQL basic test and merged TPC-DS SQLs when not skipped
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b44d7579f2624bacbf9f597eb3b281f5c3ce0a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->