### PR TITLE
chore: Bump version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "riffle-ctl"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "riffle-server"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "allocator-api2",
  "anyhow",

--- a/riffle-ctl/Cargo.toml
+++ b/riffle-ctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riffle-ctl"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 
 [[bin]]

--- a/riffle-server/Cargo.toml
+++ b/riffle-server/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "riffle-server"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 
 [profile.release]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `riffle-ctl` and `riffle-server` to version 0.19.0 and updates Cargo.lock accordingly.
> 
> - **Release/Versioning**:
>   - Update `riffle-ctl` and `riffle-server` versions to `0.19.0` in `riffle-ctl/Cargo.toml`, `riffle-server/Cargo.toml`, and `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d26be17d1aafaa66bd9dad79547afc0f61b95b08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->