### PR TITLE
fix: flaky test of urpc#test_client

### DIFF
--- a/riffle-server/src/urpc/client.rs
+++ b/riffle-server/src/urpc/client.rs
@@ -139,6 +139,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use tokio::sync::broadcast::Sender;
+    use tokio::time;
 
     fn setup_urpc_server(port: u16) -> Result<Sender<()>> {
         let mut config = Config::create_simple_config();
@@ -167,9 +168,12 @@ mod tests {
     #[test]
     fn test_client() -> Result<()> {
         let port = util::find_available_port().unwrap();
-        let shutdown_hook = setup_urpc_server(port)?;
+        let _ = setup_urpc_server(port)?;
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        // force sleep 1s to wait urpc start
+        time::sleep(Duration::from_secs(1));
+
+        let rt = tokio::runtime::Runtime::new()?;
         let f = rt.block_on(async move {
             let mut client = UrpcClient::connect("0.0.0.0", port as usize).await.unwrap();
             let command = GetLocalDataRequestCommand {

--- a/riffle-server/src/urpc/client.rs
+++ b/riffle-server/src/urpc/client.rs
@@ -139,7 +139,6 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use tokio::sync::broadcast::Sender;
-    use tokio::time;
 
     fn setup_urpc_server(port: u16) -> Result<Sender<()>> {
         let mut config = Config::create_simple_config();
@@ -171,7 +170,7 @@ mod tests {
         let _ = setup_urpc_server(port)?;
 
         // force sleep 1s to wait urpc start
-        time::sleep(Duration::from_secs(1));
+        thread::sleep(Duration::from_secs(1));
 
         let rt = tokio::runtime::Runtime::new()?;
         let f = rt.block_on(async move {

--- a/riffle-server/src/urpc/client.rs
+++ b/riffle-server/src/urpc/client.rs
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_client() -> Result<()> {
         let port = util::find_available_port().unwrap();
-        let _ = setup_urpc_server(port)?;
+        let shutdown_hook = setup_urpc_server(port)?;
 
         // force sleep 1s to wait urpc start
         thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a 1s startup wait and replace unwrap with error propagation in `test_client` to reduce flakiness.
> 
> - **Tests**
>   - Update `riffle-server/src/urpc/client.rs` `test_client`:
>     - Add `thread::sleep(Duration::from_secs(1))` to wait for URPC server startup before connecting.
>     - Replace `tokio::runtime::Runtime::new().unwrap()` with `tokio::runtime::Runtime::new()?` to propagate init errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d0fd3b04e732241c61e39deb630d3d7b24a0807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->