### PR TITLE
fix(ci): With token to avoid api limit on setup-protoc

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - name: Code style check
         working-directory: ./
@@ -64,6 +65,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: Build


### PR DESCRIPTION
fix the api limit like this with the doc 

```
- name: Install Protoc
  uses: arduino/setup-protoc@v3
  with:
    repo-token: ${{ secrets.GITHUB_TOKEN }}
```

<img width="1450" height="213" alt="image" src="https://github.com/user-attachments/assets/6ce30fe4-62c1-4bd5-b938-787b72625dec" />
