### PR TITLE
feat(io-uring): Introduce zero-copy reads to socket using `splice`

### DIFF
--- a/riffle-server/src/client_configs.rs
+++ b/riffle-server/src/client_configs.rs
@@ -8,7 +8,15 @@ use std::collections::HashMap;
 pub static SENDFILE_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(|| {
     ClientConfigOption::key("spark.rss.riffle.urpcSendfileEnabled")
         .default_value(false)
-        .with_description("This indicates whether the sendfile is enabled when urpc is activated")
+        .with_description("This indicates whether the sendfile is enabled when urpc is activated without io-uring.")
+});
+
+pub static SPLICE_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(|| {
+    ClientConfigOption::key("spark.rss.riffle.urpcSpliceEnabled")
+        .default_value(false)
+        .with_description(
+            "This indicates whether the splice is enabled when urpc is activated with io-uring.",
+        )
 });
 
 pub static HDFS_CLIENT_EAGER_LOADING_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -149,6 +149,9 @@ pub struct IoUringConfig {
     pub threads: usize,
     #[serde(default = "as_default_io_uring_io_depth")]
     pub io_depth: usize,
+
+    #[serde(default = "bool::default")]
+    pub read_splice_enbaled: bool,
 }
 
 fn as_default_io_uring_io_depth() -> usize {

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -134,7 +134,7 @@ pub struct LocalfileStoreConfig {
 
     pub io_limiter: Option<IoLimiterConfig>,
 
-    // This is only for urpc
+    // This is only for urpc without uring
     #[serde(default = "as_default_read_io_sendfile_enable")]
     pub read_io_sendfile_enable: bool,
 

--- a/riffle-server/src/lib.rs
+++ b/riffle-server/src/lib.rs
@@ -65,3 +65,5 @@ pub mod mini_riffle;
 mod partition_stats;
 mod raw_io;
 mod system_libc;
+
+pub mod raw_pipe;

--- a/riffle-server/src/main.rs
+++ b/riffle-server/src/main.rs
@@ -111,6 +111,8 @@ pub mod ddashmap;
 
 pub mod partition_stats;
 
+pub mod raw_pipe;
+
 const MAX_MEMORY_ALLOCATION_SIZE_ENV_KEY: &str = "MAX_MEMORY_ALLOCATION_LIMIT_SIZE";
 
 #[derive(Parser, Debug)]

--- a/riffle-server/src/raw_pipe.rs
+++ b/riffle-server/src/raw_pipe.rs
@@ -1,0 +1,19 @@
+use std::fs::File;
+use std::os::fd::{AsRawFd, RawFd};
+
+#[derive(Debug)]
+pub struct RawPipe {
+    pub pipe_in_fd: File,
+    pub pipe_out_fd: File,
+    pub length: usize,
+}
+
+impl RawPipe {
+    pub fn from(pipe_in_fd: File, pipe_out_fd: File, length: usize) -> Self {
+        Self {
+            pipe_in_fd,
+            pipe_out_fd,
+            length,
+        }
+    }
+}

--- a/riffle-server/src/store/local/read_options.rs
+++ b/riffle-server/src/store/local/read_options.rs
@@ -65,9 +65,12 @@ impl ReadRange {
 #[derive(Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub enum IoMode {
+    // only valid for read in linux
     SENDFILE,
     DIRECT_IO,
     BUFFER_IO,
+    // only valid for read in linux io-uring engine
+    SPLICE,
 }
 
 impl Default for ReadOptions {
@@ -120,6 +123,11 @@ impl ReadOptions {
 
     pub fn with_sendfile(mut self) -> Self {
         self.io_mode = IoMode::SENDFILE;
+        self
+    }
+
+    pub fn with_splice(mut self) -> Self {
+        self.io_mode = IoMode::SPLICE;
         self
     }
 

--- a/riffle-server/src/store/local/sync_io.rs
+++ b/riffle-server/src/store/local/sync_io.rs
@@ -192,7 +192,7 @@ impl SyncLocalIO {
                     DataBytes::Composed(composed) => {
                         buf_writer.write_all(&composed.freeze())?;
                     }
-                    DataBytes::RawIO(_) => todo!(),
+                    _ => todo!(),
                 }
                 buf_writer.flush()?;
 
@@ -430,7 +430,7 @@ impl LocalIO for SyncLocalIO {
         options: ReadOptions,
     ) -> anyhow::Result<DataBytes, WorkerError> {
         let data = match options.io_mode {
-            IoMode::SENDFILE => {
+            IoMode::SENDFILE | IoMode::SPLICE => {
                 let (off, len) = match options.read_range {
                     ReadRange::RANGE(off, len) => (off, len),
                     _ => {

--- a/riffle-server/src/store/mod.rs
+++ b/riffle-server/src/store/mod.rs
@@ -44,6 +44,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use crate::composed_bytes::ComposedBytes;
 use crate::config_reconfigure::ReconfigurableConfManager;
 use crate::raw_io::RawIO;
+use crate::raw_pipe::RawPipe;
 use crate::runtime::manager::RuntimeManager;
 use crate::store::index_codec::IndexCodec;
 use crate::store::spill::SpillWritingViewContext;
@@ -143,6 +144,7 @@ pub enum DataBytes {
     Direct(Bytes),
     Composed(ComposedBytes),
     RawIO(RawIO),
+    RawPipe(RawPipe),
 }
 
 impl Into<DataBytes> for Bytes {
@@ -163,6 +165,7 @@ impl DataBytes {
             DataBytes::Direct(bytes) => bytes.len(),
             DataBytes::Composed(composed) => composed.len(),
             DataBytes::RawIO(io_handle) => io_handle.length as usize,
+            DataBytes::RawPipe(pipe_handle) => pipe_handle.length,
         }
     }
 

--- a/riffle-server/src/system_libc.rs
+++ b/riffle-server/src/system_libc.rs
@@ -214,9 +214,14 @@ pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> Result<()> {
 #[cfg(test)]
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod tests {
+    use crate::runtime::manager::create_runtime;
+    use crate::store::DataBytes;
+
     use super::*;
+    use bytes::buf;
     use libc::{shutdown, SHUT_WR};
     use std::fs::{File, OpenOptions};
+    use std::io::Read;
     use std::io::Seek;
     use std::io::Write;
     use std::os::fd::AsRawFd;
@@ -224,6 +229,65 @@ mod tests {
     use tokio::io::AsyncReadExt;
     use tokio::net::{TcpListener, TcpStream};
     use tokio::task;
+
+    fn generate_14mb_string() -> String {
+        const MB14: usize = 14 * 1024 * 1024;
+        let pattern = "ABCD";
+        let repeat_count = MB14 / pattern.len();
+        let remainder = MB14 % pattern.len();
+
+        let mut s = pattern.repeat(repeat_count);
+        s.push_str(&pattern[..remainder]);
+        s
+    }
+
+    // only test splice on linux
+    #[cfg(all(feature = "io-uring", target_os = "linux"))]
+    #[test]
+    fn test_splice() -> anyhow::Result<()> {
+        use rand::Rng;
+
+        const FILE_SIZE: usize = 150 * 1024 * 1024;
+        const CHUNK_SIZE: usize = 15 * 1024 * 1024;
+        const NUM_CHUNKS: usize = FILE_SIZE / CHUNK_SIZE;
+
+        let w_runtime = create_runtime(2, "w");
+
+        let listener =
+            w_runtime.block_on(async { TcpListener::bind("127.0.0.1:0").await.unwrap() });
+        let addr = listener.local_addr().unwrap();
+
+        let server = w_runtime.spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            socket.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+
+        let mut stream = w_runtime.block_on(async { TcpStream::connect(addr).await.unwrap() });
+
+        use crate::store::local::uring_io::tests::read_with_splice;
+
+        let write_data = generate_14mb_string();
+
+        println!("validating with direct read...");
+        let result = read_with_splice(write_data.to_owned())?;
+        match result {
+            DataBytes::RawPipe(raw_pipe) => {
+                assert!(raw_pipe.length == write_data.len());
+                println!("Have read into the pipe");
+                w_runtime.block_on(async { splice(&mut stream, &raw_pipe).await })?;
+                let ret = unsafe { shutdown(stream.as_raw_fd(), SHUT_WR) };
+                assert_eq!(ret, 0, "shutdown failed");
+            }
+            _ => panic!("Expected raw pipe bytes"),
+        };
+
+        let accepted = w_runtime.block_on(async { server.await })?;
+        assert_eq!(accepted.as_slice(), write_data.as_bytes());
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_send_file_full_linux() {


### PR DESCRIPTION
Limited by the linux kernel version of 5.10 in anolisos8.10 . we have to use the `splice` to make zero-copy possible 