### PR TITLE
feat(io-uring): Refactor and introduce the `urpcReadIoMode` for client

### DIFF
--- a/riffle-ctl/src/actions/disk_read_bench.rs
+++ b/riffle-ctl/src/actions/disk_read_bench.rs
@@ -8,7 +8,7 @@ use riffle_server::runtime::manager::{create_runtime, RuntimeManager};
 use riffle_server::runtime::RuntimeRef;
 use riffle_server::store::local::io_layer_read_ahead::ReadAheadLayer;
 use riffle_server::store::local::layers::Handler;
-use riffle_server::store::local::read_options::{ReadOptions, ReadRange};
+use riffle_server::store::local::read_options::{IoMode, ReadOptions, ReadRange};
 use riffle_server::store::local::sync_io::SyncLocalIO;
 use riffle_server::store::local::LocalIO;
 use std::fs::{self, File, OpenOptions};
@@ -136,7 +136,7 @@ impl Action for DiskReadBenchAction {
                 let mut duration = 0;
                 for batch_idx in 0..batch_number {
                     let batch_start = Instant::now();
-                    let options = ReadOptions::default().with_buffer_io().with_read_range(ReadRange::RANGE(offset, read_size));
+                    let options = ReadOptions::default().with_io_mode(IoMode::BUFFER_IO).with_read_range(ReadRange::RANGE(offset, read_size));
                     let _data = handler
                         .read(file_name.as_str(), options)
                         .await;

--- a/riffle-server/src/app_manager.rs
+++ b/riffle-server/src/app_manager.rs
@@ -440,13 +440,13 @@ pub(crate) mod test {
             data_distribution: DataDistribution::NORMAL,
             max_concurrency_per_partition_to_write: 0,
             remote_storage_config_option: None,
-            sendfile_enable: false,
             // activate read ahead
             read_ahead_enable: true,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             client_configs: Default::default(),
             get_memory_data_urpc_version: Default::default(),
+            read_io_mode: Default::default(),
         };
         app_manager_ref
             .register(raw_app_id.to_string(), shuffle_id, app_options)

--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -230,7 +230,7 @@ impl App {
         self.heartbeat()?;
 
         // with the read mode.
-        let ctx = ctx.with_urpc_read_io_mode(self.app_config_options.urpc_read_io_mode.clone());
+        let ctx = ctx.with_io_mode(self.app_config_options.urpc_read_io_mode.clone());
 
         let ctx = if self.app_config_options.read_ahead_enable {
             // This is a workaround — we can infer sequential reads when the taskId filter bitmap is enabled.

--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -229,11 +229,8 @@ impl App {
     pub async fn select(&self, ctx: ReadingViewContext) -> Result<ResponseData, WorkerError> {
         self.heartbeat()?;
 
-        let ctx = if (self.app_config_options.sendfile_enable) {
-            ctx.with_sendfile_enabled()
-        } else {
-            ctx
-        };
+        // with the read mode.
+        let ctx = ctx.with_urpc_read_io_mode(self.app_config_options.urpc_read_io_mode.clone());
 
         let ctx = if self.app_config_options.read_ahead_enable {
             // This is a workaround — we can infer sequential reads when the taskId filter bitmap is enabled.

--- a/riffle-server/src/app_manager/app.rs
+++ b/riffle-server/src/app_manager/app.rs
@@ -230,7 +230,7 @@ impl App {
         self.heartbeat()?;
 
         // with the read mode.
-        let ctx = ctx.with_io_mode(self.app_config_options.urpc_read_io_mode.clone());
+        let ctx = ctx.with_io_mode(self.app_config_options.read_io_mode.clone());
 
         let ctx = if self.app_config_options.read_ahead_enable {
             // This is a workaround — we can infer sequential reads when the taskId filter bitmap is enabled.

--- a/riffle-server/src/app_manager/app_configs.rs
+++ b/riffle-server/src/app_manager/app_configs.rs
@@ -2,7 +2,7 @@ use crate::app_manager::request_context::PurgeDataContext;
 use crate::client_configs::{
     ClientConfigOption, ClientRssConf, GET_MEMORY_DATA_URPC_VERSION,
     HDFS_CLIENT_EAGER_LOADING_ENABLED_OPTION, READ_AHEAD_BATCH_NUMBER, READ_AHEAD_BATCH_SIZE,
-    READ_AHEAD_ENABLED_OPTION, URPC_READ_IO_MODE_OPTION,
+    READ_AHEAD_ENABLED_OPTION, READ_IO_MODE_OPTION,
 };
 use crate::config::RpcVersion;
 use crate::grpc::protobuf::uniffle::RemoteStorage;
@@ -36,7 +36,7 @@ pub struct AppConfigOptions {
     pub get_memory_data_urpc_version: RpcVersion,
 
     // urpc_read_io_mode
-    pub urpc_read_io_mode: IoMode,
+    pub read_io_mode: IoMode,
 
     // all client configs
     pub client_configs: ClientRssConf,
@@ -61,8 +61,8 @@ impl AppConfigOptions {
             get_memory_data_urpc_version: rss_config
                 .get(&GET_MEMORY_DATA_URPC_VERSION)
                 .unwrap_or(RpcVersion::V1),
-            urpc_read_io_mode: rss_config
-                .get(&URPC_READ_IO_MODE_OPTION)
+            read_io_mode: rss_config
+                .get(&READ_IO_MODE_OPTION)
                 .unwrap_or(IoMode::BUFFER_IO),
             client_configs: rss_config,
         }
@@ -80,7 +80,7 @@ impl Default for AppConfigOptions {
             read_ahead_batch_size: None,
             client_configs: Default::default(),
             get_memory_data_urpc_version: RpcVersion::V1,
-            urpc_read_io_mode: Default::default(),
+            read_io_mode: Default::default(),
         }
     }
 }
@@ -90,7 +90,7 @@ impl Display for AppConfigOptions {
         write!(
             f,
             "data_distribution={}, urpc_read_io_mode={}, read_ahead_enable={}",
-            &self.data_distribution, self.urpc_read_io_mode, self.read_ahead_enable
+            &self.data_distribution, self.read_io_mode, self.read_ahead_enable
         )
     }
 }

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -125,7 +125,8 @@ pub struct ReadingViewContext {
     pub localfile_next_read_segments: Vec<ReadSegment>,
     pub task_id: i64,
 
-    pub urpc_read_io_mode: IoMode,
+    // read io mode
+    pub io_mode: IoMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,7 +148,7 @@ impl ReadingViewContext {
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
             task_id: 0,
-            urpc_read_io_mode: Default::default(),
+            io_mode: Default::default(),
         }
     }
 
@@ -158,7 +159,7 @@ impl ReadingViewContext {
     }
 
     pub fn with_io_mode(mut self, mode: IoMode) -> Self {
-        self.urpc_read_io_mode = mode;
+        self.io_mode = mode;
         self
     }
 

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -3,6 +3,7 @@ use crate::app_manager::partition_identifier::PartitionUId;
 use crate::app_manager::purge_event::PurgeReason;
 use crate::id_layout::IdLayout;
 use crate::partition_stats::{PartitionStats, TaskToRecordStatRef};
+use crate::store::local::read_options::IoMode;
 use crate::store::Block;
 use crate::urpc::command::ReadSegment;
 use bytes::Bytes;
@@ -111,7 +112,6 @@ pub struct ReadingViewContext {
     pub reading_options: ReadingOptions,
     pub task_ids_filter: Option<Treemap>,
     pub rpc_source: RpcType,
-    pub sendfile_enabled: bool,
 
     // tag whether the read-ahead is enabled
     pub read_ahead_client_enabled: bool,
@@ -124,6 +124,8 @@ pub struct ReadingViewContext {
     // next read segments
     pub localfile_next_read_segments: Vec<ReadSegment>,
     pub task_id: i64,
+
+    pub urpc_read_io_mode: IoMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -139,13 +141,13 @@ impl ReadingViewContext {
             reading_options,
             task_ids_filter: None,
             rpc_source,
-            sendfile_enabled: false,
             read_ahead_client_enabled: false,
             sequential: false,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
             task_id: 0,
+            urpc_read_io_mode: Default::default(),
         }
     }
 
@@ -155,8 +157,8 @@ impl ReadingViewContext {
         self
     }
 
-    pub fn with_sendfile_enabled(mut self) -> Self {
-        self.sendfile_enabled = true;
+    pub fn with_urpc_read_io_mode(mut self, mode: IoMode) -> Self {
+        self.urpc_read_io_mode = mode;
         self
     }
 

--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -157,7 +157,7 @@ impl ReadingViewContext {
         self
     }
 
-    pub fn with_urpc_read_io_mode(mut self, mode: IoMode) -> Self {
+    pub fn with_io_mode(mut self, mode: IoMode) -> Self {
         self.urpc_read_io_mode = mode;
         self
     }

--- a/riffle-server/src/client_configs.rs
+++ b/riffle-server/src/client_configs.rs
@@ -1,22 +1,13 @@
 use crate::config::RpcVersion;
+use crate::store::local::read_options::IoMode;
 use crate::util;
 use clap::builder::Str;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
 /// The configuration options related to riffle-servers on the Uniffle client side.
-pub static SENDFILE_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(|| {
-    ClientConfigOption::key("spark.rss.riffle.urpcSendfileEnabled")
-        .default_value(false)
-        .with_description("This indicates whether the sendfile is enabled when urpc is activated without io-uring.")
-});
-
-pub static SPLICE_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(|| {
-    ClientConfigOption::key("spark.rss.riffle.urpcSpliceEnabled")
-        .default_value(false)
-        .with_description(
-            "This indicates whether the splice is enabled when urpc is activated with io-uring.",
-        )
+pub static URPC_READ_IO_MODE_OPTION: Lazy<ClientConfigOption<IoMode>> = Lazy::new(|| {
+    ClientConfigOption::key("spark.rss.riffle.urpcReadIoMode").default_value(IoMode::BUFFER_IO)
 });
 
 pub static HDFS_CLIENT_EAGER_LOADING_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(
@@ -164,26 +155,5 @@ mod tests {
     fn test_no_default_value() {
         let conf = ClientRssConf::default();
         assert_eq!(None, conf.get(&READ_AHEAD_BATCH_SIZE));
-    }
-
-    #[test]
-    fn test_sendfile_enabled_option_default() {
-        let conf = ClientRssConf {
-            properties: HashMap::new(),
-        };
-        let result = conf.get(&SENDFILE_ENABLED_OPTION);
-        assert_eq!(result, Some(false));
-    }
-
-    #[test]
-    fn test_sendfile_enabled_option_set_true() {
-        let mut props = HashMap::new();
-        props.insert(
-            "spark.rss.riffle.urpcSendfileEnabled".to_string(),
-            "true".to_string(),
-        );
-        let conf = ClientRssConf { properties: props };
-        let result = conf.get(&SENDFILE_ENABLED_OPTION);
-        assert_eq!(result, Some(true));
     }
 }

--- a/riffle-server/src/client_configs.rs
+++ b/riffle-server/src/client_configs.rs
@@ -6,8 +6,9 @@ use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
 /// The configuration options related to riffle-servers on the Uniffle client side.
-pub static URPC_READ_IO_MODE_OPTION: Lazy<ClientConfigOption<IoMode>> = Lazy::new(|| {
-    ClientConfigOption::key("spark.rss.riffle.urpcReadIoMode").default_value(IoMode::BUFFER_IO)
+pub static READ_IO_MODE_OPTION: Lazy<ClientConfigOption<IoMode>> = Lazy::new(|| {
+    ClientConfigOption::key("spark.rss.riffle.readIoMode").default_value(IoMode::BUFFER_IO)
+        .with_description("Io mode for reading, but sendfile is only valid in urpc without uring and splice is only valid in urpc with uring!")
 });
 
 pub static HDFS_CLIENT_EAGER_LOADING_ENABLED_OPTION: Lazy<ClientConfigOption<bool>> = Lazy::new(

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -118,10 +118,6 @@ pub struct LocalfileStoreConfig {
     #[serde(default = "as_default_disk_healthy_check_interval_sec")]
     pub disk_healthy_check_interval_sec: u64,
 
-    #[serde(default = "as_default_direct_io_enable")]
-    pub direct_io_enable: bool,
-    #[serde(default = "as_default_direct_io_read_enable")]
-    pub direct_io_read_enable: bool,
     #[serde(default = "as_default_direct_io_append_enable")]
     pub direct_io_append_enable: bool,
 
@@ -259,8 +255,6 @@ impl LocalfileStoreConfig {
             disk_write_buf_capacity: as_default_disk_write_buf_capacity(),
             disk_read_buf_capacity: as_default_disk_read_buf_capacity(),
             disk_healthy_check_interval_sec: as_default_disk_healthy_check_interval_sec(),
-            direct_io_enable: as_default_direct_io_enable(),
-            direct_io_read_enable: as_default_direct_io_read_enable(),
             direct_io_append_enable: as_default_direct_io_append_enable(),
             io_duration_threshold_sec: as_default_io_duration_threshold_sec(),
             index_consistency_detection_enable: false,

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -134,10 +134,6 @@ pub struct LocalfileStoreConfig {
 
     pub io_limiter: Option<IoLimiterConfig>,
 
-    // This is only for urpc without uring
-    #[serde(default = "as_default_read_io_sendfile_enable")]
-    pub read_io_sendfile_enable: bool,
-
     pub read_ahead_options: Option<ReadAheadConfig>,
 
     pub io_uring_options: Option<IoUringConfig>,
@@ -149,9 +145,6 @@ pub struct IoUringConfig {
     pub threads: usize,
     #[serde(default = "as_default_io_uring_io_depth")]
     pub io_depth: usize,
-
-    #[serde(default = "bool::default")]
-    pub read_splice_enbaled: bool,
 }
 
 fn as_default_io_uring_io_depth() -> usize {
@@ -272,7 +265,6 @@ impl LocalfileStoreConfig {
             io_duration_threshold_sec: as_default_io_duration_threshold_sec(),
             index_consistency_detection_enable: false,
             io_limiter: None,
-            read_io_sendfile_enable: as_default_read_io_sendfile_enable(),
             read_ahead_options: None,
             io_uring_options: None,
         }

--- a/riffle-server/src/mini_riffle.rs
+++ b/riffle-server/src/mini_riffle.rs
@@ -187,13 +187,13 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             reading_options: ReadingOptions::MEMORY_LAST_BLOCK_ID_AND_MAX_SIZE(-1, 10000000),
             task_ids_filter: None,
             rpc_source: RpcType::GRPC,
-            sendfile_enabled: false,
             read_ahead_client_enabled: false,
             sequential: false,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
             task_id: 0,
+            urpc_read_io_mode: Default::default(),
         })
         .await?;
     let mut total_partition_len = 0;
@@ -205,13 +205,13 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             reading_options: ReadingOptions::FILE_OFFSET_AND_LEN(0, data.len() as i64),
             task_ids_filter: None,
             rpc_source: RpcType::GRPC,
-            sendfile_enabled: false,
             read_ahead_client_enabled: false,
             sequential: false,
             read_ahead_batch_number: None,
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
             task_id: 0,
+            urpc_read_io_mode: Default::default(),
         })
         .await?;
     let xdata = response.from_local();

--- a/riffle-server/src/mini_riffle.rs
+++ b/riffle-server/src/mini_riffle.rs
@@ -193,7 +193,7 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
             task_id: 0,
-            urpc_read_io_mode: Default::default(),
+            io_mode: Default::default(),
         })
         .await?;
     let mut total_partition_len = 0;
@@ -211,7 +211,7 @@ pub async fn shuffle_testing(config: &Config, app_ref: AppManagerRef) -> anyhow:
             read_ahead_batch_size: None,
             localfile_next_read_segments: vec![],
             task_id: 0,
-            urpc_read_io_mode: Default::default(),
+            io_mode: Default::default(),
         })
         .await?;
     let xdata = response.from_local();

--- a/riffle-server/src/store/local/io_layer_read_ahead.rs
+++ b/riffle-server/src/store/local/io_layer_read_ahead.rs
@@ -376,7 +376,7 @@ mod tests {
     use super::*;
     use crate::error::WorkerError;
     use crate::runtime::manager::create_runtime;
-    use crate::store::local::read_options::{ReadOptions, ReadRange};
+    use crate::store::local::read_options::{IoMode, ReadOptions, ReadRange};
     use crate::store::local::FileStat;
     use crate::store::local::{CreateOptions, LocalIO, WriteOptions};
     use crate::store::DataBytes;
@@ -425,7 +425,7 @@ mod tests {
 
         // 1st read ahead
         let options = ReadOptions::default()
-            .with_buffer_io()
+            .with_io_mode(IoMode::BUFFER_IO)
             .with_read_range(ReadRange::RANGE(0, 5))
             .with_ahead_options(AheadOptions {
                 sequential: true,
@@ -495,7 +495,7 @@ mod tests {
         };
 
         let options = ReadOptions::default()
-            .with_buffer_io()
+            .with_io_mode(IoMode::BUFFER_IO)
             .with_read_range(ReadRange::RANGE(0, 1))
             .with_ahead_options(AheadOptions {
                 sequential: false,

--- a/riffle-server/src/store/local/read_options.rs
+++ b/riffle-server/src/store/local/read_options.rs
@@ -16,7 +16,10 @@
 // under the License.
 
 use crate::app_manager::request_context::PurgeDataContext;
+use crate::config::RpcVersion;
 use crate::urpc::command::ReadSegment;
+use std::str::FromStr;
+use strum_macros::Display;
 
 #[derive(Clone, Debug)]
 pub struct ReadOptions {
@@ -62,7 +65,7 @@ impl ReadRange {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
 #[allow(non_camel_case_types)]
 pub enum IoMode {
     // only valid for read in linux
@@ -71,6 +74,34 @@ pub enum IoMode {
     BUFFER_IO,
     // only valid for read in linux io-uring engine
     SPLICE,
+}
+
+impl IoMode {
+    pub(crate) fn fallback(self) -> Self {
+        if matches!(&self, IoMode::SPLICE) || matches!(self, IoMode::SENDFILE) {
+            return IoMode::BUFFER_IO;
+        }
+        self
+    }
+}
+
+impl Default for IoMode {
+    fn default() -> Self {
+        IoMode::BUFFER_IO
+    }
+}
+
+impl FromStr for IoMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_uppercase().as_str() {
+            "SENDFILE" => IoMode::SENDFILE,
+            "DIRECT_IO" => IoMode::DIRECT_IO,
+            "SPLICE" => IoMode::SPLICE,
+            _ => IoMode::BUFFER_IO,
+        })
+    }
 }
 
 impl Default for ReadOptions {
@@ -100,34 +131,13 @@ impl ReadOptions {
         self
     }
 
-    pub fn with_read_all(mut self) -> Self {
-        self.io_mode = IoMode::BUFFER_IO;
-        self.read_range = ReadRange::ALL;
-        self
-    }
-
     pub fn with_read_range(mut self, range: ReadRange) -> Self {
         self.read_range = range;
         self
     }
 
-    pub fn with_buffer_io(mut self) -> Self {
-        self.io_mode = IoMode::BUFFER_IO;
-        self
-    }
-
-    pub fn with_direct_io(mut self) -> Self {
-        self.io_mode = IoMode::DIRECT_IO;
-        self
-    }
-
-    pub fn with_sendfile(mut self) -> Self {
-        self.io_mode = IoMode::SENDFILE;
-        self
-    }
-
-    pub fn with_splice(mut self) -> Self {
-        self.io_mode = IoMode::SPLICE;
+    pub fn with_io_mode(mut self, io_mode: IoMode) -> Self {
+        self.io_mode = io_mode;
         self
     }
 
@@ -173,7 +183,7 @@ mod test {
         assert_eq!(opts.ahead_options.is_some(), true);
 
         // with_read_all
-        let opts2 = ReadOptions::default().with_read_all();
+        let opts2 = ReadOptions::default().with_read_range(ReadRange::ALL);
         assert!(matches!(opts2.io_mode, IoMode::BUFFER_IO));
         assert!(matches!(opts2.read_range, ReadRange::ALL));
         assert_eq!(opts2.ahead_options.is_some(), false);
@@ -184,17 +194,17 @@ mod test {
         assert_eq!(opts3.ahead_options.is_some(), false);
 
         // with_buffer_io
-        let opts4 = ReadOptions::default().with_buffer_io();
+        let opts4 = ReadOptions::default().with_io_mode(IoMode::BUFFER_IO);
         assert!(matches!(opts4.io_mode, IoMode::BUFFER_IO));
         assert_eq!(opts4.ahead_options.is_some(), false);
 
         // with_direct_io
-        let opts5 = ReadOptions::default().with_direct_io();
+        let opts5 = ReadOptions::default().with_io_mode(IoMode::DIRECT_IO);
         assert!(matches!(opts5.io_mode, IoMode::DIRECT_IO));
         assert_eq!(opts5.ahead_options.is_some(), false);
 
         // with_sendfile
-        let opts6 = ReadOptions::default().with_sendfile();
+        let opts6 = ReadOptions::default().with_io_mode(IoMode::SENDFILE);
         assert!(matches!(opts6.io_mode, IoMode::SENDFILE));
         assert_eq!(opts6.ahead_options.is_some(), false);
     }

--- a/riffle-server/src/store/local/read_options.rs
+++ b/riffle-server/src/store/local/read_options.rs
@@ -77,9 +77,11 @@ pub enum IoMode {
 }
 
 impl IoMode {
-    pub(crate) fn fallback(self) -> Self {
-        if matches!(&self, IoMode::SPLICE) || matches!(self, IoMode::SENDFILE) {
-            return IoMode::BUFFER_IO;
+    pub(crate) fn fallback(self, exclusive: Vec<IoMode>, to: IoMode) -> Self {
+        for mode in exclusive {
+            if matches!(&self, mode) {
+                return to;
+            }
         }
         self
     }

--- a/riffle-server/src/store/local/sync_io.rs
+++ b/riffle-server/src/store/local/sync_io.rs
@@ -509,7 +509,7 @@ mod test {
     use crate::store::alignment::io_buffer_pool::IoBufferPool;
     use crate::store::alignment::io_bytes::IoBuffer;
     use crate::store::local::options::WriteOptions;
-    use crate::store::local::read_options::{ReadOptions, ReadRange};
+    use crate::store::local::read_options::{IoMode, ReadOptions, ReadRange};
     use crate::store::local::sync_io::{fill_buffer_and_write, SyncLocalIO, ALIGN};
     use crate::store::local::LocalIO;
     use bytes::{Bytes, BytesMut};
@@ -559,7 +559,7 @@ mod test {
         assert_eq!(1000 * 3, stat.content_length);
 
         // read all
-        let options = ReadOptions::default().with_read_all();
+        let options = ReadOptions::default().with_read_range(ReadRange::ALL);
         let data = base_runtime_ref
             .block_on(io_handler.read(data_file_name, options))?
             .freeze();
@@ -567,7 +567,7 @@ mod test {
 
         // seek read
         let options = ReadOptions::default()
-            .with_buffer_io()
+            .with_io_mode(IoMode::BUFFER_IO)
             .with_read_range(ReadRange::RANGE(10, 20));
         let data = base_runtime_ref
             .block_on(io_handler.read(data_file_name, options))?
@@ -711,14 +711,14 @@ mod test {
         // read
         let options = ReadOptions::default()
             .with_read_range(ReadRange::RANGE(3, 3))
-            .with_direct_io();
+            .with_io_mode(IoMode::DIRECT_IO);
         let data_1 = base_runtime_ref
             .block_on(io_handler.read(data_file_name, options))?
             .freeze();
         assert_eq!(vec![b'y', b'y', b'z'], data_1);
 
         let options = ReadOptions::default()
-            .with_direct_io()
+            .with_io_mode(IoMode::DIRECT_IO)
             .with_read_range(ReadRange::RANGE(11, 4));
         let data_2 = base_runtime_ref
             .block_on(io_handler.read(data_file_name, options))?
@@ -726,7 +726,7 @@ mod test {
         assert_eq!(vec![b'x', b'x', b'y', b'y'], data_2);
 
         let options = ReadOptions::default()
-            .with_direct_io()
+            .with_io_mode(IoMode::DIRECT_IO)
             .with_read_range(ReadRange::RANGE(19, 2));
         let data_3 = base_runtime_ref
             .block_on(io_handler.read(data_file_name, options))?

--- a/riffle-server/tests/write_read.rs
+++ b/riffle-server/tests/write_read.rs
@@ -44,12 +44,6 @@ mod tests {
         config.hybrid_store.memory_single_buffer_max_spill_size = Some("1B".to_string());
         config.localfile_store.as_mut().unwrap().disk_high_watermark = 1.0;
 
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        {
-            let localfile_config = config.localfile_store.as_mut().unwrap();
-            localfile_config.read_io_sendfile_enable = true
-        }
-
         let _app_ref = mini_riffle::start(&config).await?;
         // wait all setup
         tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
# Changelog
1. Refactor and introduce the `urpcReadIoMode` to involve `bufferIo` / `directIo` / `sendfile` / `splice` for client
2. Remove the `direct_io_read_enabled` options in riffle side