### PR TITLE
feat(io-uring): Add metric for splice

### DIFF
--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -690,6 +690,10 @@ pub static GAUGE_GRPC_REQUEST_QUEUE_SIZE: Lazy<IntGauge> = Lazy::new(|| {
     IntGauge::new("grpc_request_number", "current service request queue size").unwrap()
 });
 
+pub static TOTAL_URING_SPLICE: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new("total_uring_splice_number", "total_uring_splice_number").expect("")
+});
+
 pub static TOTAL_SPILL_EVENTS_DROPPED: Lazy<IntCounter> = Lazy::new(|| {
     IntCounter::new(
         "total_spill_events_dropped",
@@ -1075,6 +1079,10 @@ fn register_custom_metrics() {
 
     REGISTRY
         .register(Box::new(TOTAL_SPILL_EVENTS_DROPPED.clone()))
+        .expect("");
+
+    REGISTRY
+        .register(Box::new(TOTAL_URING_SPLICE.clone()))
         .expect("");
 
     REGISTRY

--- a/riffle-server/src/store/local/uring_io.rs
+++ b/riffle-server/src/store/local/uring_io.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::error::WorkerError;
+use crate::metric::TOTAL_URING_SPLICE;
 use crate::raw_pipe::RawPipe;
 use crate::store::local::options::{CreateOptions, WriteOptions};
 use crate::store::local::read_options::{IoMode, ReadOptions, ReadRange};
@@ -492,6 +493,7 @@ impl LocalIO for UringIo {
 
         // todo: make the size as the optional config option in io-uring
         if matches!(options.io_mode, IoMode::SPLICE) && length < 16 * 1024 * 1024 {
+            TOTAL_URING_SPLICE.inc();
             // init the pipe
             let (pipe_in, mut pipe_out) = {
                 let mut pipes = [0, 0];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds visibility into io_uring splice usage.
> 
> - Introduces and registers `TOTAL_URING_SPLICE` Prometheus counter in `metric.rs`
> - Increments `TOTAL_URING_SPLICE` in `uring_io.rs` when `IoMode::SPLICE` is taken for reads smaller than 16MB
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63a746510c520c86f1afb5f61022b624c3fad716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->