### PR TITLE
fix: Must register hard-split metric

### DIFF
--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -1317,6 +1317,10 @@ fn register_custom_metrics() {
     REGISTRY
         .register(Box::new(READ_AHEAD_OPERATION_FAILURE_COUNT.clone()))
         .expect("read_ahead_operation_failure_count must be registered");
+
+    REGISTRY
+        .register(Box::new(HARD_SPLIT_COUNTER.clone()))
+        .expect("");
 }
 
 const JOB_NAME: &str = "uniffle-worker";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the hard-split metric is exposed via Prometheus.
> 
> - Registers `HARD_SPLIT_COUNTER` in `register_custom_metrics()` so `hard_split_count` is gathered and pushed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8afe13156e9b2c7a77190ff108205169a0070005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->