### PR TITLE
feat(rpc): Abort core-affinity in aarch64 to improve performance

### DIFF
--- a/riffle-server/src/rpc.rs
+++ b/riffle-server/src/rpc.rs
@@ -76,7 +76,7 @@ impl DefaultRpcService {
         {
             let rx = tx.subscribe();
             let app_manager = app_manager_ref.clone();
-            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), urpc_port as u16);
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), urpc_port);
 
             std::thread::spawn(move || {
                 tokio::runtime::Builder::new_multi_thread()
@@ -95,7 +95,7 @@ impl DefaultRpcService {
                 let rx = tx.subscribe();
 
                 let app_manager = app_manager_ref.clone();
-                let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), urpc_port as u16);
+                let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), urpc_port);
 
                 std::thread::spawn(move || {
                     core_affinity::set_for_current(core_id);
@@ -130,7 +130,7 @@ impl DefaultRpcService {
             for (_, core_id) in core_ids.into_iter().enumerate() {
                 let shuffle_server =
                     DefaultShuffleServer::from(app_manager_ref.clone(), server_state_manager);
-                let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), grpc_port as u16);
+                let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), grpc_port);
                 let service = ShuffleServerServer::new(shuffle_server.clone())
                     .max_decoding_message_size(usize::MAX)
                     .max_encoding_message_size(usize::MAX);
@@ -160,7 +160,7 @@ impl DefaultRpcService {
         {
             let shuffle_server =
                 DefaultShuffleServer::from(app_manager_ref.clone(), server_state_manager);
-            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), grpc_port as u16);
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), grpc_port);
             let service = ShuffleServerServer::new(shuffle_server.clone())
                 .max_decoding_message_size(usize::MAX)
                 .max_encoding_message_size(usize::MAX);


### PR DESCRIPTION
# Motivation

When deploying the Riffle cluster on aarch64 machines running AnolisOS 8, I observed that RPC performance was significantly degraded. Metrics from the await-tree and Prometheus indicated long tail latencies, which caused client connection timeouts, as shown in the logs below. Interestingly, the same version of the cluster running on x86_64 machines exhibited no such issues.

<img width="1778" height="727" alt="image" src="https://github.com/user-attachments/assets/5b4357a3-419a-4619-98c5-8d382b70db69" />

# Changelogs

After investigation, the root cause was identified as the way RPC sockets were bound:
1. On ARM, the previous per-core listener model with a single-threaded runtime and core affinity caused IO starvation and backlog accumulation.
2. Weak memory ordering and higher atomic/futex costs on aarch64 amplified the problem, preventing timely draining of socket buffers.

To address this, the following changes were made:

## ARM-specific adjustments:
1. Use a single listener per service instead of per-core listeners.
2. Switch to a multi-threaded tokio runtime (≤4 worker threads) to allow concurrent IO and task processing.
3. Disable core affinity and SO_REUSEPORT to let the scheduler balance load naturally.

## x86_64 behavior remains unchanged:
1. Retains per-core listeners, single-threaded runtime, core affinity, and SO_REUSEPORT, preserving prior tail-latency optimizations.

These changes significantly improve RPC throughput and reduce p99 latency on ARM while keeping x86 performance intact.

# Benchmark

| Scenario | Shuffle Write Time | Shuffle Read Time | Notes |
|----------|-----------|----------|-------|
| Without this patch | 5.7 min | 12 min | 3 Spark tasks failed due to RPC timeouts |
| With this patch    | 4.4 min | 6.3 min  | All tasks completed successfully |

**Benchmark description:**  
- Dataset: 2TB TeraSort input  
- Cluster: aarch64 machines with anolisos8 linux (kernel 5.10), 400 concurrent Spark tasks  
