### PR TITLE
feat(urpc): add metric of urpc_request_number

### DIFF
--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -694,9 +694,11 @@ pub static TOTAL_GRPC_REQUEST: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static GAUGE_GRPC_REQUEST_QUEUE_SIZE: Lazy<IntGauge> = Lazy::new(|| {
-    IntGauge::new("grpc_request_number", "current service request queue size").unwrap()
-});
+pub static GAUGE_URPC_REQUEST_QUEUE_SIZE: Lazy<IntGauge> =
+    Lazy::new(|| IntGauge::new("urpc_request_number", "urpc service request queue size").unwrap());
+
+pub static GAUGE_GRPC_REQUEST_QUEUE_SIZE: Lazy<IntGauge> =
+    Lazy::new(|| IntGauge::new("grpc_request_number", "grpc service request queue size").unwrap());
 
 pub static TOTAL_URING_SPLICE: Lazy<IntCounter> = Lazy::new(|| {
     IntCounter::new("total_uring_splice_number", "total_uring_splice_number").expect("")

--- a/riffle-server/src/metric.rs
+++ b/riffle-server/src/metric.rs
@@ -1084,6 +1084,10 @@ fn register_custom_metrics() {
         .expect("");
 
     REGISTRY
+        .register(Box::new(GAUGE_URPC_REQUEST_QUEUE_SIZE.clone()))
+        .expect("");
+
+    REGISTRY
         .register(Box::new(GAUGE_GRPC_REQUEST_QUEUE_SIZE.clone()))
         .expect("");
 

--- a/riffle-server/src/urpc/metrics.rs
+++ b/riffle-server/src/urpc/metrics.rs
@@ -1,0 +1,36 @@
+use crate::metric::{
+    GAUGE_URPC_REQUEST_QUEUE_SIZE, TOTAL_URPC_REQUEST, URPC_REQUEST_PROCESSING_LATENCY,
+};
+use crate::urpc::frame::Frame;
+use prometheus::HistogramTimer;
+
+pub struct RequestMetricTracker {
+    rpc_path: String,
+    process_timer: HistogramTimer,
+}
+
+impl RequestMetricTracker {
+    pub fn new(frame: &Frame) -> Self {
+        let timer = URPC_REQUEST_PROCESSING_LATENCY
+            .with_label_values(&[&format!("{}", &frame)])
+            .start_timer();
+        RequestMetricTracker {
+            rpc_path: frame.to_string(),
+            process_timer: timer,
+        }
+    }
+
+    pub fn start(&self) {
+        TOTAL_URPC_REQUEST.with_label_values(&[&"ALL"]).inc();
+        TOTAL_URPC_REQUEST
+            .with_label_values(&[self.rpc_path.as_str()])
+            .inc();
+        GAUGE_URPC_REQUEST_QUEUE_SIZE.inc();
+    }
+}
+
+impl Drop for RequestMetricTracker {
+    fn drop(&mut self) {
+        GAUGE_URPC_REQUEST_QUEUE_SIZE.dec();
+    }
+}

--- a/riffle-server/src/urpc/mod.rs
+++ b/riffle-server/src/urpc/mod.rs
@@ -3,5 +3,6 @@ pub mod client;
 pub mod command;
 pub mod connection;
 pub mod frame;
+mod metrics;
 pub mod server;
 pub mod shutdown;

--- a/riffle-server/src/urpc/server.rs
+++ b/riffle-server/src/urpc/server.rs
@@ -16,6 +16,7 @@ use crate::metric::{
     TOTAL_GRPC_REQUEST, TOTAL_URPC_REQUEST, URPC_CONNECTION_NUMBER, URPC_REQUEST_PROCESSING_LATENCY,
 };
 use crate::urpc::command::Command;
+use crate::urpc::metrics::RequestMetricTracker;
 use anyhow::Result;
 use await_tree::InstrumentAwait;
 use socket2::SockRef;
@@ -117,13 +118,10 @@ impl Handler {
                 None => return Ok(()),
             };
 
-            let path = frame.to_string();
-            TOTAL_URPC_REQUEST.with_label_values(&[&"ALL"]).inc();
-            TOTAL_URPC_REQUEST.with_label_values(&[&path]).inc();
+            // metric collector for the urpc request
+            let tracker = RequestMetricTracker::new(&frame);
+            tracker.start();
 
-            let timer = URPC_REQUEST_PROCESSING_LATENCY
-                .with_label_values(&[&format!("{}", &frame)])
-                .start_timer();
             let await_root = await_registry
                 .register(format!(
                     "urpc connection with remote client: {}",


### PR DESCRIPTION
Sometimes the RPC service hangs, and I notice that grpc_request_number is high, indicating long RPC processing times. This PR adds a metric to track the number of active uRPC requests.