### PR TITLE
fix(localfile)(uring): writing iovec chunked on exceeding UIO_MAXIOV limit

### DIFF
--- a/riffle-server/src/store/local/uring_io.rs
+++ b/riffle-server/src/store/local/uring_io.rs
@@ -40,6 +40,9 @@ use std::{
 };
 use tokio::sync::oneshot;
 
+/// Linux kernel limit on the number of iovec entries per writev call.
+pub(crate) const UIO_MAXIOV: usize = 1024;
+
 /// Builder for io_uring based I/O engine.
 #[derive(Debug)]
 pub struct UringIoEngineBuilder {
@@ -404,12 +407,8 @@ impl LocalIO for UringIo {
     }
 
     async fn write(&self, path: &str, options: WriteOptions) -> anyhow::Result<(), WorkerError> {
-        let (tx, rx) = oneshot::channel();
-        let tag = options.data.len();
-        let shard = &self.write_txs[tag % self.write_txs.len()];
         let byte_size = options.data.len();
         let bufs = options.data.always_bytes();
-        let buf_len = bufs.len();
 
         let path = self.with_root(path);
         let path = Path::new(&path);
@@ -433,20 +432,7 @@ impl LocalIO for UringIo {
             (_, None) => 0,
         };
 
-        let mut ctx = UringIoCtx {
-            tx,
-            io_type: UringIoType::WriteV,
-            addr: RawFileAddress {
-                file: RawFile(raw_fd),
-                offset: io_uring_offset,
-            },
-            w_bufs: bufs,
-            w_iovecs: Vec::with_capacity(buf_len),
-            r_bufs: vec![],
-            splice_pipe: None,
-        };
-        ctx.w_iovecs = ctx
-            .w_bufs
+        let all_iovecs: Vec<iovec> = bufs
             .iter()
             .map(|b| iovec {
                 iov_base: b.as_ptr() as *mut _,
@@ -454,16 +440,51 @@ impl LocalIO for UringIo {
             })
             .collect();
 
-        let _ = shard.send(ctx);
-        let written_bytes = match rx.await {
-            Ok(res) => res,
-            Err(e) => Err(WorkerError::Other(anyhow::Error::from(e))),
-        }?;
-        if (byte_size != written_bytes) {
+        let mut total_written: usize = 0;
+        for chunk in all_iovecs.chunks(UIO_MAXIOV) {
+            let (tx, rx) = oneshot::channel();
+            let shard = &self.write_txs[byte_size % self.write_txs.len()];
+
+            let chunk_bytes: usize = chunk.iter().map(|v| v.iov_len).sum();
+            let batch_offset = if io_uring_offset == u64::MAX {
+                u64::MAX
+            } else {
+                io_uring_offset + total_written as u64
+            };
+
+            let ctx = UringIoCtx {
+                tx,
+                io_type: UringIoType::WriteV,
+                addr: RawFileAddress {
+                    file: RawFile(raw_fd),
+                    offset: batch_offset,
+                },
+                w_bufs: vec![],
+                w_iovecs: chunk.to_vec(),
+                r_bufs: vec![],
+                splice_pipe: None,
+            };
+
+            let _ = shard.send(ctx);
+            let written = match rx.await {
+                Ok(res) => res,
+                Err(e) => Err(WorkerError::Other(anyhow::Error::from(e))),
+            }?;
+            if written != chunk_bytes {
+                return Err(WorkerError::Other(anyhow!(
+                    "Unexpected io write. expected/written: {}/{}",
+                    chunk_bytes,
+                    written
+                )));
+            }
+            total_written += written;
+        }
+
+        if total_written != byte_size {
             return Err(WorkerError::Other(anyhow!(
-                "Unexpected io write. expected/written: {}/{}",
+                "Unexpected total io write. expected/written: {}/{}",
                 byte_size,
-                written_bytes
+                total_written
             )));
         }
         Ok(())
@@ -841,6 +862,78 @@ pub mod tests {
                 .unwrap()
         });
         Ok(result)
+    }
+
+    #[test]
+    fn test_uring_writev_exceeding_uio_maxiov() -> anyhow::Result<()> {
+        use crate::store::local::uring_io::UIO_MAXIOV;
+        use crate::store::DataBytes;
+        use bytes::Bytes;
+        use tempdir::TempDir;
+
+        let temp_dir = TempDir::new("test_writev_exceed_maxiov")?;
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let r_runtime = create_runtime(1, "r");
+        let w_runtime = create_runtime(2, "w");
+
+        let sync_io_engine =
+            SyncLocalIO::new(&r_runtime, &w_runtime, temp_path.as_str(), None, None);
+        let uring_io_engine = UringIoEngineBuilder::new().build(sync_io_engine)?;
+
+        let num_bufs = UIO_MAXIOV + 500;
+        let mut segments = Vec::with_capacity(num_bufs);
+        let mut expected = BytesMut::new();
+        for i in 0..num_bufs {
+            let chunk = Bytes::from(format!("block-{:06}", i));
+            expected.put(chunk.as_ref());
+            segments.push(chunk);
+        }
+        let total_len = segments.iter().map(|b| b.len()).sum::<usize>();
+
+        // write with offset (simulating direct_io_append_enable path)
+        let write_options = crate::store::local::options::WriteOptions {
+            append: true,
+            offset: Some(0),
+            data: DataBytes::Composed(ComposedBytes::from(segments, total_len)),
+        };
+
+        w_runtime.block_on(async {
+            uring_io_engine
+                .write("test_exceed_maxiov", write_options)
+                .await
+                .unwrap();
+        });
+
+        // read back and verify
+        let read_options = crate::store::local::read_options::ReadOptions {
+            io_mode: IoMode::SENDFILE,
+            task_id: 0,
+            read_range: crate::store::local::read_options::ReadRange::ALL,
+            ahead_options: None,
+        };
+
+        let result = r_runtime.block_on(async {
+            uring_io_engine
+                .read("test_exceed_maxiov", read_options)
+                .await
+                .unwrap()
+        });
+
+        match result {
+            DataBytes::Direct(bytes) => assert_eq!(bytes.as_ref(), expected.as_ref()),
+            DataBytes::RawIO(raw_io) => {
+                let mut buf = vec![0u8; raw_io.length as usize];
+                let mut file = unsafe { std::fs::File::from_raw_fd(raw_io.raw_fd) };
+                file.seek(std::io::SeekFrom::Start(raw_io.offset))?;
+                file.read_exact(&mut buf)?;
+                assert_eq!(buf.as_slice(), expected.as_ref());
+                std::mem::forget(file);
+            }
+            _ => panic!("Expected direct bytes or raw IO"),
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/riffle-server/src/store/local/uring_io.rs
+++ b/riffle-server/src/store/local/uring_io.rs
@@ -410,22 +410,35 @@ impl LocalIO for UringIo {
         let byte_size = options.data.len();
         let bufs = options.data.always_bytes();
         let buf_len = bufs.len();
-        let slices = bufs
-            .iter()
-            .map(|x| IoSlice::new(x.as_ref()))
-            .collect::<Vec<_>>();
 
         let path = self.with_root(path);
         let path = Path::new(&path);
-        let mut file = OpenOptions::new().append(true).create(true).open(path)?;
+        let mut open_options = OpenOptions::new();
+        open_options.create(true);
+        if options.append && options.offset.is_none() {
+            open_options.append(true);
+        } else {
+            open_options.write(true);
+            if !options.append {
+                open_options.truncate(true);
+            }
+        }
+        let file = open_options.open(path)?;
         let raw_fd = file.as_raw_fd();
+        let io_uring_offset = match (options.append, options.offset) {
+            // For buffered append, io_uring writev should use current file position
+            // (same behavior as writev with offset = -1).
+            (true, None) => u64::MAX,
+            (_, Some(offset)) => offset,
+            (_, None) => 0,
+        };
 
         let mut ctx = UringIoCtx {
             tx,
             io_type: UringIoType::WriteV,
             addr: RawFileAddress {
                 file: RawFile(raw_fd),
-                offset: options.offset.unwrap_or(0),
+                offset: io_uring_offset,
             },
             w_bufs: bufs,
             w_iovecs: Vec::with_capacity(buf_len),
@@ -697,6 +710,87 @@ pub mod tests {
                 file.read_exact(&mut buf)?;
                 assert_eq!(buf.as_slice(), expected.as_ref());
                 // still keep file
+                std::mem::forget(file);
+            }
+            _ => panic!("Expected direct bytes or raw IO"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_uring_buffer_append_without_offset() -> anyhow::Result<()> {
+        use crate::store::DataBytes;
+        use bytes::Bytes;
+        use tempdir::TempDir;
+
+        let temp_dir = TempDir::new("test_write_append_none")?;
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let r_runtime = create_runtime(1, "r");
+        let w_runtime = create_runtime(2, "w");
+
+        let sync_io_engine =
+            SyncLocalIO::new(&r_runtime, &w_runtime, temp_path.as_str(), None, None);
+        let uring_io_engine = UringIoEngineBuilder::new().build(sync_io_engine)?;
+
+        let first = b"append-first-";
+        let second = b"append-second";
+
+        w_runtime.block_on(async {
+            uring_io_engine
+                .write(
+                    "test_file_append_none",
+                    crate::store::local::options::WriteOptions {
+                        append: true,
+                        offset: None,
+                        data: DataBytes::Direct(Bytes::from(&first[..])),
+                    },
+                )
+                .await
+                .unwrap();
+        });
+        w_runtime.block_on(async {
+            uring_io_engine
+                .write(
+                    "test_file_append_none",
+                    crate::store::local::options::WriteOptions {
+                        append: true,
+                        offset: None,
+                        data: DataBytes::Direct(Bytes::from(&second[..])),
+                    },
+                )
+                .await
+                .unwrap();
+        });
+
+        let result = r_runtime.block_on(async {
+            uring_io_engine
+                .read(
+                    "test_file_append_none",
+                    crate::store::local::read_options::ReadOptions {
+                        io_mode: IoMode::SENDFILE,
+                        task_id: 0,
+                        read_range: crate::store::local::read_options::ReadRange::ALL,
+                        ahead_options: None,
+                    },
+                )
+                .await
+                .unwrap()
+        });
+
+        let mut expected = BytesMut::new();
+        expected.put(first.as_ref());
+        expected.put(second.as_ref());
+
+        match result {
+            DataBytes::Direct(bytes) => assert_eq!(bytes.as_ref(), expected.as_ref()),
+            DataBytes::RawIO(raw_io) => {
+                let mut buf = vec![0u8; raw_io.length as usize];
+                let mut file = unsafe { std::fs::File::from_raw_fd(raw_io.raw_fd) };
+                file.seek(std::io::SeekFrom::Start(raw_io.offset))?;
+                file.read_exact(&mut buf)?;
+                assert_eq!(buf.as_slice(), expected.as_ref());
                 std::mem::forget(file);
             }
             _ => panic!("Expected direct bytes or raw IO"),

--- a/riffle-server/src/store/local/uring_io.rs
+++ b/riffle-server/src/store/local/uring_io.rs
@@ -432,25 +432,25 @@ impl LocalIO for UringIo {
             (_, None) => 0,
         };
 
-        let all_iovecs: Vec<iovec> = bufs
-            .iter()
-            .map(|b| iovec {
-                iov_base: b.as_ptr() as *mut _,
-                iov_len: b.len(),
-            })
-            .collect();
-
         let mut total_written: usize = 0;
-        for chunk in all_iovecs.chunks(UIO_MAXIOV) {
+        for buf_chunk in bufs.chunks(UIO_MAXIOV) {
             let (tx, rx) = oneshot::channel();
             let shard = &self.write_txs[byte_size % self.write_txs.len()];
 
-            let chunk_bytes: usize = chunk.iter().map(|v| v.iov_len).sum();
+            let chunk_bytes: usize = buf_chunk.iter().map(|b| b.len()).sum();
             let batch_offset = if io_uring_offset == u64::MAX {
                 u64::MAX
             } else {
                 io_uring_offset + total_written as u64
             };
+
+            let chunk_iovecs: Vec<iovec> = buf_chunk
+                .iter()
+                .map(|b| iovec {
+                    iov_base: b.as_ptr() as *mut _,
+                    iov_len: b.len(),
+                })
+                .collect();
 
             let ctx = UringIoCtx {
                 tx,
@@ -460,7 +460,7 @@ impl LocalIO for UringIo {
                     offset: batch_offset,
                 },
                 w_bufs: vec![],
-                w_iovecs: chunk.to_vec(),
+                w_iovecs: chunk_iovecs,
                 r_bufs: vec![],
                 splice_pipe: None,
             };


### PR DESCRIPTION
## Problem
When spilling to LOCALFILE with the io_uring backend, writes may fail intermittently with RAW_IO_ERR(-22) (EINVAL). This happens under high load when a single spill batch contains many small blocks.

<img width="1902" height="201" alt="image" src="https://github.com/user-attachments/assets/2bc8ba27-5f99-40ea-87d8-641153dd5575" />

Root cause: io_uring uses IORING_OP_WRITEV, and Linux enforces a hard limit (UIO_MAXIOV = 1024) on the number of iovec entries per writev. If the spill batch expands to more than 1024 segments, the kernel rejects the request with EINVAL.

## Fix
Split io_uring writev submissions into multiple batches, each with at most UIO_MAXIOV iovecs.
For offset-based writes, advance the offset by the number of bytes written in previous batches.
Keep append semantics intact when using “current file position” (offset = u64::MAX).

## Tests
Add test_uring_writev_exceeding_uio_maxiov, which writes a composed payload with more than 1024 segments and verifies the content is correctly persisted and readable.