### PR TITLE
fix(urpc): ensure await-tree is registered only once to prevent significant performance regression

### DIFF
--- a/riffle-server/src/urpc/server.rs
+++ b/riffle-server/src/urpc/server.rs
@@ -105,6 +105,12 @@ impl Handler {
     /// util it reaches a safe state, at which point it is terminated
     async fn run(&mut self, app_manager_ref: AppManagerRef) -> Result<(), WorkerError> {
         let await_registry = AWAIT_TREE_REGISTRY.clone();
+        let await_root = await_registry
+            .register(format!(
+                "urpc connection with remote client: {}",
+                &self.remote_addr
+            ))
+            .await;
         while !self.shutdown.is_shutdown() {
             let maybe_frame = tokio::select! {
                 res = self.connection.read_frame() => res?,
@@ -118,16 +124,9 @@ impl Handler {
                 None => return Ok(()),
             };
 
-            // metric collector for the urpc request
             let tracker = RequestMetricTracker::new(&frame);
             tracker.start();
 
-            let await_root = await_registry
-                .register(format!(
-                    "urpc connection with remote client: {}",
-                    &self.remote_addr
-                ))
-                .await;
             await_root
                 .instrument(Command::from_frame(frame)?.apply(
                     app_manager_ref.clone(),

--- a/riffle-server/src/urpc/server.rs
+++ b/riffle-server/src/urpc/server.rs
@@ -55,14 +55,18 @@ impl Listener {
                 remote_addr: addr.to_string(),
             };
 
-            tokio::spawn(async move {
+            let await_registry = AWAIT_TREE_REGISTRY.clone();
+            let await_root = await_registry
+                .register(format!("urpc connection with remote client: {}", addr))
+                .await;
+            tokio::spawn(await_root.instrument(async move {
                 URPC_CONNECTION_NUMBER.inc();
                 if let Err(error) = handler.run(app_manager).await {
                     error!("Errors on handling the request. {:#?}", error);
                 }
                 drop(permit);
                 URPC_CONNECTION_NUMBER.dec();
-            });
+            }));
         }
     }
 
@@ -104,13 +108,6 @@ impl Handler {
     /// when the shutdown signal is received, the connection is processed
     /// util it reaches a safe state, at which point it is terminated
     async fn run(&mut self, app_manager_ref: AppManagerRef) -> Result<(), WorkerError> {
-        let await_registry = AWAIT_TREE_REGISTRY.clone();
-        let await_root = await_registry
-            .register(format!(
-                "urpc connection with remote client: {}",
-                &self.remote_addr
-            ))
-            .await;
         while !self.shutdown.is_shutdown() {
             let maybe_frame = tokio::select! {
                 res = self.connection.read_frame() => res?,
@@ -127,12 +124,13 @@ impl Handler {
             let tracker = RequestMetricTracker::new(&frame);
             tracker.start();
 
-            await_root
-                .instrument(Command::from_frame(frame)?.apply(
+            Command::from_frame(frame)?
+                .apply(
                     app_manager_ref.clone(),
                     &mut self.connection,
                     &mut self.shutdown,
-                ))
+                )
+                .instrument_await("handling request...")
                 .await?;
         }
         Ok(())


### PR DESCRIPTION
<img width="1163" height="881" alt="image" src="https://github.com/user-attachments/assets/24d46649-c24d-4413-90af-13d54f05c4e7" />

## Per-Request await_tree Registration (17.5% + 9.4% CPU)
After resolving the channel contention, the profile revealed a new hotspot: 17.5% in _Unwind_Backtrace and 9.4% in pthread_mutex_lock. The call chain was:


_Unwind_Backtrace → _Unwind_Find_FDE → __dl_iterate_phdr → pthread_mutex_lock
The await_tree registry's register() call captures a backtrace internally. This was placed inside the per-request loop in Handler::run(), meaning every single request triggered a full DWARF stack unwind. The __dl_iterate_phdr function acquires a global glibc mutex, causing severe contention under concurrent requests.

Fix: Moved await_tree registration from per-request to per-connection scope (once at connection setup, reused for all subsequent requests on that connection).