### PR TITLE
feat(ctl): show running_apps in instances table

### DIFF
--- a/riffle-ctl/src/actions/discovery.rs
+++ b/riffle-ctl/src/actions/discovery.rs
@@ -3,6 +3,7 @@ use futures::future::try_join_all;
 use riffle_server::historical_apps::HistoricalAppInfo;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::str::FromStr;
 use strum_macros::Display;
 
@@ -136,6 +137,24 @@ impl Discovery {
         self.fetch_from_node_api("/apps?format=Json").await
     }
 
+    pub async fn count_running_apps_per_node(&self) -> Result<HashMap<(String, usize), usize>> {
+        let server_infos = self.list_nodes().await?;
+        let mut future_list = vec![];
+        for info in server_infos {
+            let ip = info.ip.clone();
+            let http_port = info.http_port;
+            let future = async move { fetch_running_app_count(ip, http_port).await };
+            future_list.push(tokio::spawn(future));
+        }
+        let results = try_join_all(future_list)
+            .await
+            .map_err(|x| anyhow!("Error happened. err: {}", x))?;
+        Ok(results
+            .into_iter()
+            .filter_map(Result::ok)
+            .collect::<HashMap<_, _>>())
+    }
+
     pub async fn list_historical_apps(&self) -> Result<Vec<HistoricalAppInfo>> {
         self.fetch_from_node_api("/apps/history").await
     }
@@ -172,6 +191,25 @@ impl Discovery {
             .collect::<Vec<T>>();
         Ok(all_apps)
     }
+}
+
+async fn fetch_running_app_count(
+    ip: String,
+    http_port: usize,
+) -> Result<((String, usize), usize), reqwest::Error> {
+    let number_url = format!("http://{}:{}/apps/number", &ip, http_port);
+    if let Ok(response) = reqwest::get(&number_url).await {
+        if response.status().is_success() {
+            if let Ok(count) = response.json::<usize>().await {
+                return Ok(((ip, http_port), count));
+            }
+        }
+    }
+
+    let apps_url = format!("http://{}:{}/apps?format=Json", &ip, http_port);
+    let response = reqwest::get(&apps_url).await?;
+    let apps = response.json::<Vec<ActiveAppInfo>>().await?;
+    Ok(((ip, http_port), apps.len()))
 }
 
 #[cfg(test)]

--- a/riffle-ctl/src/actions/query.rs
+++ b/riffle-ctl/src/actions/query.rs
@@ -49,13 +49,13 @@ pub struct TableInstance {
 
     pub total_memory: String,
     pub used_memory: String,
-    pub event_num_in_flush: usize,
+    pub running_apps: usize,
     pub tags: String,
     pub status: ServerStatus,
 }
 
-impl From<&ServerInfo> for TableInstance {
-    fn from(info: &ServerInfo) -> Self {
+impl From<(&ServerInfo, usize)> for TableInstance {
+    fn from((info, running_apps): (&ServerInfo, usize)) -> Self {
         Self {
             ip: info.ip.to_string(),
             grpc_port: info.grpc_port,
@@ -63,7 +63,7 @@ impl From<&ServerInfo> for TableInstance {
             http_port: info.http_port as i32,
             total_memory: HumanBytes(info.total_memory as u64).to_string(),
             used_memory: HumanBytes(info.used_memory as u64).to_string(),
-            event_num_in_flush: info.event_num_in_flush,
+            running_apps,
             tags: info
                 .tags
                 .iter()
@@ -123,9 +123,16 @@ impl SessionContextExtend {
 
     async fn register_instances(&self) -> Result<()> {
         let instances = self.discovery.list_nodes().await?;
+        let running_apps = self.discovery.count_running_apps_per_node().await?;
         let instances = instances
             .iter()
-            .map(|x| x.into())
+            .map(|info| {
+                let running_apps = running_apps
+                    .get(&(info.ip.clone(), info.http_port))
+                    .copied()
+                    .unwrap_or(0);
+                (info, running_apps).into()
+            })
             .collect::<Vec<TableInstance>>();
         self.register(instances, INSTANCES_TABLE_NAME)?;
         Ok(())

--- a/riffle-server/src/http/apps.rs
+++ b/riffle-server/src/http/apps.rs
@@ -158,6 +158,24 @@ impl Handler for AppsHandler {
     }
 }
 
+#[derive(Default)]
+pub struct AppsNumberHandler {}
+impl Handler for AppsNumberHandler {
+    fn get_route_method(&self) -> RouteMethod {
+        RouteMethod::new().get(number_handler)
+    }
+
+    fn get_route_path(&self) -> String {
+        "/apps/number".to_string()
+    }
+}
+
+#[handler]
+async fn number_handler() -> Json<usize> {
+    let manager_ref = APP_MANAGER_REF.get().unwrap();
+    Json(manager_ref.get_app_count())
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 enum FormatType {
     Json,

--- a/riffle-server/src/http/mod.rs
+++ b/riffle-server/src/http/mod.rs
@@ -33,7 +33,7 @@ use crate::runtime::manager::RuntimeManager;
 
 use crate::app_manager::AppManagerRef;
 use crate::http::admin::AdminHandler;
-use crate::http::apps::AppsHandler;
+use crate::http::apps::{AppsHandler, AppsNumberHandler};
 use crate::http::historical_apps::HistoricalAppsHandler;
 use crate::http::profile_heap::ProfileHeapHandler;
 use log::info;
@@ -74,6 +74,7 @@ fn new_server() -> Box<PoemHTTPServer> {
     server.register_handler(MetricsHTTPHandler::default());
     server.register_handler(AwaitTreeHandler::default());
     server.register_handler(AppsHandler::default());
+    server.register_handler(AppsNumberHandler::default());
     server.register_handler(HistoricalAppsHandler::default());
     server.register_handler(AdminHandler::default());
 


### PR DESCRIPTION
Add /apps/number on riffle-server and fall back to the legacy apps JSON list when the endpoint is unavailable.