### PR TITLE
feat(hdfs): introduce the huge partition spill threshold config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ memory_single_buffer_max_spill_size = "1G"
 memory_spill_to_cold_threshold_size = "128M"
 memory_spill_to_localfile_concurrency = 4000
 memory_spill_to_hdfs_concurrency = 500
+# Static startup setting. Huge partitions use this single-buffer spill trigger;
+# watermark spills may still flush them earlier.
+huge_partition_memory_single_buffer_max_spill_size = "128M"
 huge_partition_memory_spill_to_hdfs_threshold_size = "64M"
 
 [runtime_config]

--- a/riffle-server/src/app_manager.rs
+++ b/riffle-server/src/app_manager.rs
@@ -587,6 +587,7 @@ pub(crate) mod test {
                 memory_spill_to_cold_threshold_size: None,
                 memory_spill_to_localfile_concurrency: None,
                 memory_spill_to_hdfs_concurrency: None,
+                huge_partition_memory_single_buffer_max_spill_size: None,
                 huge_partition_memory_spill_to_hdfs_threshold_size: Some("64M".to_string()),
                 huge_partition_fallback_enable: false,
                 sensitive_watermark_spill_enable: false,

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -327,6 +327,7 @@ pub struct HybridStoreConfig {
     pub memory_spill_to_localfile_concurrency: Option<i32>,
     pub memory_spill_to_hdfs_concurrency: Option<i32>,
 
+    pub huge_partition_memory_single_buffer_max_spill_size: Option<String>,
     pub huge_partition_memory_spill_to_hdfs_threshold_size: Option<String>,
     #[serde(default = "as_default_huge_partition_fallback_enable")]
     pub huge_partition_fallback_enable: bool,
@@ -382,6 +383,7 @@ impl HybridStoreConfig {
             memory_spill_to_cold_threshold_size: None,
             memory_spill_to_localfile_concurrency: None,
             memory_spill_to_hdfs_concurrency: None,
+            huge_partition_memory_single_buffer_max_spill_size: None,
             huge_partition_memory_spill_to_hdfs_threshold_size: None,
             huge_partition_fallback_enable: as_default_huge_partition_fallback_enable(),
             sensitive_watermark_spill_enable: as_default_sensitive_watermark_spill_enable(),
@@ -401,6 +403,7 @@ impl Default for HybridStoreConfig {
             memory_spill_to_cold_threshold_size: None,
             memory_spill_to_localfile_concurrency: None,
             memory_spill_to_hdfs_concurrency: None,
+            huge_partition_memory_single_buffer_max_spill_size: None,
             huge_partition_memory_spill_to_hdfs_threshold_size: None,
             huge_partition_fallback_enable: as_default_huge_partition_fallback_enable(),
             sensitive_watermark_spill_enable: as_default_sensitive_watermark_spill_enable(),
@@ -876,6 +879,7 @@ mod test {
         memory_spill_high_watermark = 0.8
         memory_spill_low_watermark = 0.2
         memory_single_buffer_max_spill_size = "256M"
+        huge_partition_memory_single_buffer_max_spill_size = "128M"
 
         [hdfs_store]
         max_concurrency = 10
@@ -899,6 +903,14 @@ mod test {
 
         let decoded: Config = toml::from_str(toml_str).unwrap();
         println!("{:#?}", decoded);
+
+        assert_eq!(
+            Some("128M"),
+            decoded
+                .hybrid_store
+                .huge_partition_memory_single_buffer_max_spill_size
+                .as_deref()
+        );
 
         let capacity = ByteSize::from_str(&decoded.memory_store.unwrap().capacity).unwrap();
         assert_eq!(ByteSize::from_str("1024M").unwrap(), capacity);

--- a/riffle-server/src/store/hybrid.rs
+++ b/riffle-server/src/store/hybrid.rs
@@ -117,6 +117,7 @@ pub struct HybridStore {
 
     app_manager: OnceCell<AppManagerRef>,
 
+    huge_partition_memory_single_buffer_max_spill_size: Option<u64>,
     huge_partition_memory_spill_to_hdfs_threshold_size: Option<u64>,
 
     // Only for test
@@ -170,6 +171,19 @@ impl HybridStore {
             .huge_partition_memory_spill_to_hdfs_threshold_size
             .as_ref()
             .map(|x| ByteSize::from_str(&x).unwrap().as_u64());
+        let huge_partition_single_buffer_spill_threshold = hybrid_conf
+            .huge_partition_memory_single_buffer_max_spill_size
+            .as_ref()
+            .map(|value| {
+                ByteSize::from_str(value)
+                    .unwrap_or_else(|error| {
+                        panic!(
+                            "Invalid hybrid_store.huge_partition_memory_single_buffer_max_spill_size [{}]: {}",
+                            value, error
+                        )
+                    })
+                    .as_u64()
+            });
         if huge_partition_spill_threshold.is_none() {
             info!("Huge partition spill to HDFS has been disabled.");
         }
@@ -193,6 +207,8 @@ impl HybridStore {
             event_bus,
             app_manager: OnceCell::new(),
             in_flight_bytes: Default::default(),
+            huge_partition_memory_single_buffer_max_spill_size:
+                huge_partition_single_buffer_spill_threshold,
             huge_partition_memory_spill_to_hdfs_threshold_size: huge_partition_spill_threshold
                 .clone(),
             in_flight_bytes_of_huge_partition: Default::default(),
@@ -470,6 +486,29 @@ impl HybridStore {
         self.buffer_spill_impl(uid, buffer).await
     }
 
+    fn single_buffer_spill_threshold(
+        &self,
+        uid: &PartitionUId,
+    ) -> Result<Option<u64>, WorkerError> {
+        let Some(huge_partition_threshold) =
+            &self.huge_partition_memory_single_buffer_max_spill_size
+        else {
+            return Ok(self.memory_spill_partition_max_threshold);
+        };
+        let Some(app_manager) = self.app_manager.get() else {
+            return Ok(self.memory_spill_partition_max_threshold);
+        };
+        let Some(app) = app_manager.get_app(&uid.app_id) else {
+            return Ok(self.memory_spill_partition_max_threshold);
+        };
+
+        if app.is_huge_partition(uid)? {
+            Ok(Some(*huge_partition_threshold))
+        } else {
+            Ok(self.memory_spill_partition_max_threshold)
+        }
+    }
+
     async fn buffer_spill_impl(
         &self,
         uid: &PartitionUId,
@@ -665,7 +704,7 @@ impl Store for HybridStore {
         // safe will be ensured by the buffer self.
         // if the first request has been handled, the following requests will not
         // fast skip this logic.
-        if let Some(threshold) = self.memory_spill_partition_max_threshold {
+        if let Some(threshold) = self.single_buffer_spill_threshold(&uid)? {
             let size = self.hot_store.get_buffer_staging_size(&uid)?;
             if size > threshold {
                 if let Err(err) = self.single_buffer_spill(&uid).await {

--- a/riffle-server/src/store/spill/spill_test.rs
+++ b/riffle-server/src/store/spill/spill_test.rs
@@ -28,6 +28,8 @@ pub mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    static SPILL_TEST_LOCK: Lazy<parking_lot::Mutex<()>> = Lazy::new(Default::default);
+
     #[test]
     fn test_enum_display() {
         let store_type = StorageType::HDFS;
@@ -96,6 +98,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_flush_after_app_purged() -> anyhow::Result<()> {
+        let _guard = SPILL_TEST_LOCK.lock();
         GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES.set(0);
         TOTAL_SPILL_EVENTS_DROPPED_WITH_APP_NOT_FOUND.reset();
         TOTAL_MEMORY_SPILL_BYTES.reset();
@@ -154,6 +157,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_flush_failed() {
+        let _guard = SPILL_TEST_LOCK.lock();
         TOTAL_MEMORY_SPILL_OPERATION_FAILED.reset();
         TOTAL_SPILL_EVENTS_DROPPED.reset();
 
@@ -209,6 +213,7 @@ pub mod tests {
     // for sensitive watermark-spill mechanism
     #[tokio::test]
     async fn test_watermark_spill_of_excluding_inflight() -> anyhow::Result<()> {
+        let _guard = SPILL_TEST_LOCK.lock();
         GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES.set(0);
 
         let warm_healthy = Arc::new(AtomicBool::new(true));
@@ -329,6 +334,7 @@ pub mod tests {
     #[tokio::test]
     #[cfg(feature = "hdfs")]
     async fn test_single_buffer_spill() {
+        let _guard = SPILL_TEST_LOCK.lock();
         GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES.set(0);
 
         let warm_healthy = Arc::new(AtomicBool::new(true));
@@ -374,8 +380,123 @@ pub mod tests {
     }
 
     #[tokio::test]
+    async fn test_huge_partition_single_buffer_spill_threshold() -> anyhow::Result<()> {
+        let _guard = SPILL_TEST_LOCK.lock();
+        let warm_healthy = Arc::new(AtomicBool::new(true));
+        let warm = MockStore::new(LOCALFILE, &warm_healthy, None, None);
+        let cold_healthy = Arc::new(AtomicBool::new(true));
+        let cold = MockStore::new(HDFS, &cold_healthy, None, None);
+
+        let temp_dir = tempdir::TempDir::new("test_huge_partition_single_buffer_spill").unwrap();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let mut config = create_multi_level_config(
+            StorageType::MEMORY_LOCALFILE,
+            1,
+            "1M".to_string(),
+            temp_path,
+        );
+        config.hybrid_store.memory_spill_high_watermark = 1.0;
+        config
+            .hybrid_store
+            .huge_partition_memory_single_buffer_max_spill_size = Some("128B".to_string());
+        config
+            .hybrid_store
+            .huge_partition_memory_spill_to_hdfs_threshold_size = Some("14B".to_string());
+        config.app_config.partition_limit_enable = true;
+        config.app_config.partition_limit_threshold = "100B".to_string();
+
+        let reconf_manager = ReconfigurableConfManager::new(&config, None)?;
+        let store = create_hybrid_store(&config, &warm, Some(&cold), &reconf_manager);
+        let app_manager = AppManager::get_ref(
+            store.runtime_manager.clone(),
+            config,
+            &store,
+            &reconf_manager,
+        );
+        store.with_app_manager(&app_manager);
+
+        let app_id = ApplicationId::mock();
+        let shuffle_id = 1;
+        let huge_partition_id = 0;
+        let normal_partition_id = 1;
+        app_manager.register(app_id.to_string(), shuffle_id, Default::default())?;
+        let app = app_manager.get_app(&app_id).unwrap();
+
+        app.insert(mock_writing_context(
+            &app_id,
+            shuffle_id,
+            normal_partition_id,
+            1,
+            20,
+        ))
+        .await?;
+        awaitility::at_most(Duration::from_secs(1))
+            .until(|| warm.inner.spill_insert_ops.load(SeqCst) == 1);
+
+        app.insert(mock_writing_context(
+            &app_id,
+            shuffle_id,
+            huge_partition_id,
+            1,
+            101,
+        ))
+        .await?;
+        app.insert(mock_writing_context(
+            &app_id,
+            shuffle_id,
+            huge_partition_id,
+            1,
+            27,
+        ))
+        .await?;
+
+        assert!(app.is_huge_partition(&PartitionUId::new(
+            &app_id,
+            shuffle_id,
+            huge_partition_id,
+        ))?);
+        assert_eq!(1, warm.inner.spill_insert_ops.load(SeqCst));
+        assert_eq!(0, cold.inner.spill_insert_ops.load(SeqCst));
+        assert_eq!(
+            128,
+            store.get_memory_buffer_size(&PartitionUId::new(
+                &app_id,
+                shuffle_id,
+                huge_partition_id,
+            ))?
+        );
+
+        app.insert(mock_writing_context(
+            &app_id,
+            shuffle_id,
+            huge_partition_id,
+            1,
+            1,
+        ))
+        .await?;
+        awaitility::at_most(Duration::from_secs(1)).until(|| {
+            cold.inner.spill_insert_ops.load(SeqCst) == 1
+                && store
+                    .get_memory_buffer_size(&PartitionUId::new(
+                        &app_id,
+                        shuffle_id,
+                        huge_partition_id,
+                    ))
+                    .unwrap()
+                    == 0
+                && store.get_spill_event_num().unwrap() == 0
+        });
+
+        assert_eq!(1, warm.inner.spill_insert_ops.load(SeqCst));
+        assert_eq!(1, cold.inner.spill_insert_ops.load(SeqCst));
+        Ok(())
+    }
+
+    #[tokio::test]
     #[cfg(feature = "hdfs")]
     async fn test_localfile_disk_unhealthy() {
+        let _guard = SPILL_TEST_LOCK.lock();
         GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES.set(0);
 
         // when the local disk is unhealthy, the data should be flushed
@@ -427,6 +548,7 @@ pub mod tests {
     #[tokio::test]
     #[cfg(feature = "hdfs")]
     async fn test_hdfs_failure_for_huge_partition() -> anyhow::Result<()> {
+        let _guard = SPILL_TEST_LOCK.lock();
         GAUGE_MEMORY_SPILL_IN_FLIGHT_BYTES.set(0);
 
         // for the huge partition, when the hdfs flushing failed, it should fallback


### PR DESCRIPTION
### Background
Huge partitions are currently flushed to HDFS in relatively small batches. This results in frequent HDFS append operations and generates a large volume of edit-log entries.
Under heavy workloads, the Observer NameNode cannot tail and apply these edit logs quickly enough, causing it to fall behind the Active NameNode. As a result, read requests served by the Observer NameNode experience increased latency, which impacts online HDFS read performance.
We should increase the HDFS spill batch size for huge partitions to reduce the frequency of HDFS operations and the resulting edit-log pressure.