### PR TITLE
feat(mem): introduce indexed memory buffer with lazy block-position index

### DIFF
--- a/riffle-server/Cargo.toml
+++ b/riffle-server/Cargo.toml
@@ -176,3 +176,7 @@ harness = false
 [[bench]]
 name = "urpc_streaming_parse"
 harness = false
+
+[[bench]]
+name = "memory_buffer"
+harness = false

--- a/riffle-server/benches/memory_buffer.rs
+++ b/riffle-server/benches/memory_buffer.rs
@@ -1,0 +1,243 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::Bytes;
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkGroup, BenchmarkId, Criterion,
+    Throughput,
+};
+use riffle_server::constant::INVALID_BLOCK_ID;
+use riffle_server::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
+use riffle_server::store::mem::buffer::indexed_buffer::IndexedMemoryBuffer;
+use riffle_server::store::mem::buffer::{BufferOptions, MemoryBuffer};
+use riffle_server::store::Block;
+use std::time::Duration;
+
+const BLOCK_COUNTS: &[usize] = &[1_024, 16_384];
+const BLOCK_SIZE: usize = 256;
+const APPEND_BATCH_BLOCKS: usize = 128;
+const READ_BLOCKS: usize = 256;
+const READ_BYTES: i64 = (READ_BLOCKS * BLOCK_SIZE) as i64;
+
+fn create_batches(block_count: usize) -> Vec<Vec<Block>> {
+    // Share one payload allocation to isolate buffer metadata and indexing costs.
+    let payload = Bytes::from(vec![0_u8; BLOCK_SIZE]);
+    let mut batches = Vec::with_capacity(block_count.div_ceil(APPEND_BATCH_BLOCKS));
+
+    for batch_start in (0..block_count).step_by(APPEND_BATCH_BLOCKS) {
+        let batch_end = (batch_start + APPEND_BATCH_BLOCKS).min(block_count);
+        let mut blocks = Vec::with_capacity(batch_end - batch_start);
+        for block_id in batch_start..batch_end {
+            blocks.push(Block {
+                block_id: block_id as i64,
+                length: BLOCK_SIZE as i32,
+                uncompress_length: BLOCK_SIZE as i32,
+                crc: 0,
+                data: payload.clone(),
+                task_attempt_id: block_id as i64,
+            });
+        }
+        batches.push(blocks);
+    }
+
+    batches
+}
+
+fn append_batches<B>(buffer: &B, batches: Vec<Vec<Block>>)
+where
+    B: MemoryBuffer + Send + Sync,
+{
+    for blocks in batches {
+        let size = blocks.len() * BLOCK_SIZE;
+        buffer
+            .append(blocks, size as u64)
+            .expect("benchmark blocks should be appended");
+    }
+}
+
+fn create_buffer<B>(block_count: usize) -> B
+where
+    B: MemoryBuffer + Send + Sync,
+{
+    let buffer = B::new(BufferOptions::default());
+    append_batches(&buffer, create_batches(block_count));
+    buffer
+}
+
+fn assert_get_result<B>(buffer: &B, last_block_id: i64)
+where
+    B: MemoryBuffer + Send + Sync,
+{
+    let result = buffer
+        .get(last_block_id, READ_BYTES, None)
+        .expect("benchmark read should succeed");
+    assert_eq!(result.shuffle_data_block_segments.len(), READ_BLOCKS);
+    assert_eq!(result.data.len(), READ_BYTES as usize);
+}
+
+fn bench_get_case<B>(
+    group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    implementation: &str,
+    block_count: usize,
+    cursor_name: &str,
+    last_block_id: i64,
+) where
+    B: MemoryBuffer + Send + Sync,
+{
+    let buffer = create_buffer::<B>(block_count);
+    assert_get_result(&buffer, last_block_id);
+
+    let case = format!("blocks={block_count}/state=staging/cursor={cursor_name}");
+    group.bench_function(BenchmarkId::new(implementation, case), |b| {
+        b.iter(|| {
+            let result = buffer
+                .get(black_box(last_block_id), black_box(READ_BYTES), None)
+                .expect("benchmark read should succeed");
+            black_box(result);
+        });
+    });
+}
+
+fn bench_memory_buffer_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_buffer/get");
+    group.throughput(Throughput::Bytes(READ_BYTES as u64));
+
+    for &block_count in BLOCK_COUNTS {
+        let cursor_cases = [
+            ("start", INVALID_BLOCK_ID),
+            ("middle", block_count as i64 / 2 - 1),
+            ("tail", block_count as i64 - READ_BLOCKS as i64 - 1),
+            ("missing", block_count as i64 + 1),
+        ];
+
+        for &(cursor_name, last_block_id) in &cursor_cases {
+            bench_get_case::<DefaultMemoryBuffer>(
+                &mut group,
+                "default",
+                block_count,
+                cursor_name,
+                last_block_id,
+            );
+            bench_get_case::<IndexedMemoryBuffer>(
+                &mut group,
+                "indexed",
+                block_count,
+                cursor_name,
+                last_block_id,
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_append_case<B>(
+    group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    implementation: &str,
+    block_count: usize,
+) where
+    B: MemoryBuffer + Send + Sync,
+{
+    group.bench_function(
+        BenchmarkId::new(implementation, format!("blocks={block_count}")),
+        |b| {
+            b.iter_batched(
+                || {
+                    (
+                        B::new(BufferOptions::default()),
+                        create_batches(block_count),
+                    )
+                },
+                |(buffer, batches)| {
+                    append_batches(&buffer, batches);
+                    black_box(
+                        buffer
+                            .staging_size()
+                            .expect("benchmark staging size should be available"),
+                    );
+                    // Return ownership so Criterion drops the fixture after timing.
+                    black_box(buffer)
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
+fn bench_memory_buffer_append(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_buffer/append");
+
+    for &block_count in BLOCK_COUNTS {
+        group.throughput(Throughput::Elements(block_count as u64));
+        bench_append_case::<DefaultMemoryBuffer>(&mut group, "default", block_count);
+        bench_append_case::<IndexedMemoryBuffer>(&mut group, "indexed", block_count);
+    }
+
+    group.finish();
+}
+
+fn bench_spill_case<B>(
+    group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    implementation: &str,
+    block_count: usize,
+) where
+    B: MemoryBuffer + Send + Sync,
+{
+    group.bench_function(
+        BenchmarkId::new(implementation, format!("blocks={block_count}")),
+        |b| {
+            b.iter_batched(
+                || create_buffer::<B>(block_count),
+                |buffer| {
+                    let spill_result = buffer
+                        .spill()
+                        .expect("benchmark spill should succeed")
+                        .expect("benchmark buffer should contain staging data");
+                    black_box(spill_result.flight_len());
+                    // Return ownership so Criterion drops the fixture after timing.
+                    black_box((buffer, spill_result))
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
+fn bench_memory_buffer_spill(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_buffer/spill");
+
+    for &block_count in BLOCK_COUNTS {
+        group.throughput(Throughput::Elements(block_count as u64));
+        bench_spill_case::<DefaultMemoryBuffer>(&mut group, "default", block_count);
+        bench_spill_case::<IndexedMemoryBuffer>(&mut group, "indexed", block_count);
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+        .sample_size(20);
+    targets =
+        bench_memory_buffer_get,
+        bench_memory_buffer_append,
+        bench_memory_buffer_spill
+}
+criterion_main!(benches);

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -857,8 +857,9 @@ impl Config {
 mod test {
     use crate::config::{
         as_default_app_heartbeat_timeout_min, as_default_write_concurrency_per_disk, Config,
-        RpcVersion, RuntimeConfig, StorageType, UrpcConfig, UrpcWriteMode,
+        MemoryStoreConfig, RpcVersion, RuntimeConfig, StorageType, UrpcConfig, UrpcWriteMode,
     };
+    use crate::store::mem::buffer::BufferType;
     use bytesize::ByteSize;
     use std::str::FromStr;
 
@@ -880,6 +881,21 @@ mod test {
         let config =
             Config::create_mem_localfile_config(100, "20g".to_string(), "/tmp/a".to_string());
         println!("{:#?}", config);
+    }
+
+    #[test]
+    fn indexed_memory_buffer_config_supports_legacy_name() {
+        let indexed: MemoryStoreConfig =
+            toml::from_str("capacity = \"1M\"\nbuffer_type = \"INDEXED\"").unwrap();
+        let legacy: MemoryStoreConfig =
+            toml::from_str("capacity = \"1M\"\nbuffer_type = \"EXPERIMENTAL\"").unwrap();
+
+        assert_eq!(BufferType::INDEXED, indexed.buffer_type);
+        assert_eq!(BufferType::INDEXED, legacy.buffer_type);
+
+        let encoded = toml::to_string(&indexed).unwrap();
+        assert!(encoded.contains("buffer_type = \"INDEXED\""));
+        assert!(!encoded.contains("EXPERIMENTAL"));
     }
 
     #[test]

--- a/riffle-server/src/store/hybrid.rs
+++ b/riffle-server/src/store/hybrid.rs
@@ -61,8 +61,8 @@ use crate::app_manager::AppManagerRef;
 use crate::config_reconfigure::ReconfigurableConfManager;
 use crate::runtime::manager::RuntimeManager;
 use crate::store::local::LocalfileStoreStat;
+use crate::store::mem::buffer::configured_buffer::ConfiguredMemoryBuffer;
 use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-use crate::store::mem::buffer::unified_buffer::UnifiedBuffer;
 use crate::store::mem::buffer::{BufferType, MemoryBuffer};
 use crate::store::mem::capacity::CapacitySnapshot;
 use crate::store::spill::hierarchy_event_bus::HierarchyEventBus;
@@ -92,7 +92,7 @@ const DEFAULT_MEMORY_SPILL_MAX_CONCURRENCY: i32 = 20;
 
 pub struct HybridStore {
     // Box<dyn Store> will build fail
-    pub(crate) hot_store: Arc<MemoryStore<UnifiedBuffer>>,
+    pub(crate) hot_store: Arc<MemoryStore<ConfiguredMemoryBuffer>>,
 
     pub(crate) warm_store: Option<Box<dyn PersistentStore>>,
     pub(crate) cold_store: Option<Box<dyn PersistentStore>>,
@@ -189,8 +189,8 @@ impl HybridStore {
         }
         let async_watermark_spill_enable = hybrid_conf.async_watermark_spill_trigger_enable;
 
-        // use the unified buffer to delegate the underlying concrete buffer
-        let mem_store: MemoryStore<UnifiedBuffer> =
+        // Delegate to the memory buffer implementation selected by configuration.
+        let mem_store: MemoryStore<ConfiguredMemoryBuffer> =
             MemoryStore::from(config.memory_store.unwrap(), runtime_manager.clone());
 
         let store = HybridStore {
@@ -446,7 +446,10 @@ impl HybridStore {
         Ok(Default::default())
     }
 
-    pub async fn get_memory_buffer(&self, uid: &PartitionUId) -> Result<Arc<UnifiedBuffer>> {
+    pub async fn get_memory_buffer(
+        &self,
+        uid: &PartitionUId,
+    ) -> Result<Arc<ConfiguredMemoryBuffer>> {
         self.hot_store.get_buffer(uid)
     }
 
@@ -512,7 +515,7 @@ impl HybridStore {
     async fn buffer_spill_impl(
         &self,
         uid: &PartitionUId,
-        buffer: Arc<UnifiedBuffer>,
+        buffer: Arc<ConfiguredMemoryBuffer>,
     ) -> Result<u64> {
         let spill_result = buffer.spill()?;
         if spill_result.is_none() {

--- a/riffle-server/src/store/mem/buffer.rs
+++ b/riffle-server/src/store/mem/buffer.rs
@@ -1,10 +1,8 @@
+pub mod configured_buffer;
 pub mod default_buffer;
-pub mod opt_buffer;
-pub mod unified_buffer;
+pub mod indexed_buffer;
 
 use crate::composed_bytes::ComposedBytes;
-use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-use crate::store::mem::buffer::opt_buffer::OptStagingMemoryBuffer;
 use crate::store::mem::buffer::BufferType::DEFAULT;
 use crate::store::DataBytes;
 use crate::store::{Block, DataSegment, PartitionedMemoryData};
@@ -19,10 +17,11 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Copy)]
 pub enum BufferType {
-    // the default memory_buffer type
+    // The default memory buffer type.
     DEFAULT,
-    // the experimental memory_buffer type
-    EXPERIMENTAL,
+    // The memory buffer with a block-position index.
+    #[serde(alias = "EXPERIMENTAL")]
+    INDEXED,
 }
 
 impl Default for BufferType {
@@ -124,7 +123,7 @@ pub trait MemoryBuffer {
 #[cfg(test)]
 mod test {
     use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-    use crate::store::mem::buffer::opt_buffer::OptStagingMemoryBuffer;
+    use crate::store::mem::buffer::indexed_buffer::IndexedMemoryBuffer;
     use crate::store::mem::buffer::MemoryBuffer;
     use crate::store::test_utils::create_blocks;
     use crate::store::Block;
@@ -175,7 +174,7 @@ mod test {
     #[test]
     fn test_with_block_id_zero() -> anyhow::Result<()> {
         run_test_with_block_id_zero::<DefaultMemoryBuffer>()?;
-        run_test_with_block_id_zero::<OptStagingMemoryBuffer>()?;
+        run_test_with_block_id_zero::<IndexedMemoryBuffer>()?;
         Ok(())
     }
 
@@ -197,7 +196,6 @@ mod test {
         /// case3: make all staging to spill
         let spill_result = buffer.spill()?.unwrap();
         assert_eq!(10 * 10 * 2, spill_result.flight_len);
-        assert_eq!(2, spill_result.blocks.len());
         assert_eq!(
             10 * 2,
             spill_result
@@ -283,7 +281,7 @@ mod test {
     #[test]
     fn test_put_get() -> anyhow::Result<()> {
         run_test_put_get::<DefaultMemoryBuffer>()?;
-        run_test_put_get::<OptStagingMemoryBuffer>()?;
+        run_test_put_get::<IndexedMemoryBuffer>()?;
         Ok(())
     }
 
@@ -320,7 +318,7 @@ mod test {
     #[test]
     fn test_get_v2_is_end_with_only_staging() -> anyhow::Result<()> {
         run_test_get_v2_is_end_with_only_staging::<DefaultMemoryBuffer>()?;
-        run_test_get_v2_is_end_with_only_staging::<OptStagingMemoryBuffer>()?;
+        run_test_get_v2_is_end_with_only_staging::<IndexedMemoryBuffer>()?;
         Ok(())
     }
 
@@ -352,7 +350,7 @@ mod test {
     #[test]
     fn test_get_v2_is_end_across_flight_and_staging() -> anyhow::Result<()> {
         run_test_get_v2_is_end_across_flight_and_staging::<DefaultMemoryBuffer>()?;
-        run_test_get_v2_is_end_across_flight_and_staging::<OptStagingMemoryBuffer>()?;
+        run_test_get_v2_is_end_across_flight_and_staging::<IndexedMemoryBuffer>()?;
         Ok(())
     }
 }

--- a/riffle-server/src/store/mem/buffer/configured_buffer.rs
+++ b/riffle-server/src/store/mem/buffer/configured_buffer.rs
@@ -1,24 +1,24 @@
+use crate::store::mem::buffer::configured_buffer::ConfiguredMemoryBuffer::{DEFAULT, INDEXED};
 use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-use crate::store::mem::buffer::opt_buffer::OptStagingMemoryBuffer;
-use crate::store::mem::buffer::unified_buffer::UnifiedBuffer::{DEFAULT, EXPERIMENTAL};
+use crate::store::mem::buffer::indexed_buffer::IndexedMemoryBuffer;
 use crate::store::mem::buffer::{BufferOptions, BufferSpillResult, BufferType, MemoryBuffer};
 use crate::store::{Block, PartitionedMemoryData};
 use croaring::Treemap;
 
-/// this is the router to delegate to the underlying concrete implementation without any cost
-pub enum UnifiedBuffer {
+/// Delegates to the memory buffer implementation selected by configuration.
+pub enum ConfiguredMemoryBuffer {
     DEFAULT(DefaultMemoryBuffer),
-    EXPERIMENTAL(OptStagingMemoryBuffer),
+    INDEXED(IndexedMemoryBuffer),
 }
 
-impl MemoryBuffer for UnifiedBuffer {
-    fn new(opts: BufferOptions) -> Self
+impl MemoryBuffer for ConfiguredMemoryBuffer {
+    fn new(options: BufferOptions) -> Self
     where
         Self: Sized,
     {
-        match opts.buffer_type {
-            BufferType::DEFAULT => DEFAULT(DefaultMemoryBuffer::new(opts)),
-            BufferType::EXPERIMENTAL => EXPERIMENTAL(OptStagingMemoryBuffer::new(opts)),
+        match options.buffer_type {
+            BufferType::DEFAULT => DEFAULT(DefaultMemoryBuffer::new(options)),
+            BufferType::INDEXED => INDEXED(IndexedMemoryBuffer::new(options)),
         }
     }
 
@@ -28,7 +28,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.total_size(),
-            EXPERIMENTAL(x) => x.total_size(),
+            INDEXED(x) => x.total_size(),
         }
     }
 
@@ -38,7 +38,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.flight_size(),
-            EXPERIMENTAL(x) => x.flight_size(),
+            INDEXED(x) => x.flight_size(),
         }
     }
 
@@ -48,7 +48,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.staging_size(),
-            EXPERIMENTAL(x) => x.staging_size(),
+            INDEXED(x) => x.staging_size(),
         }
     }
 
@@ -58,7 +58,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.clear(flight_id, flight_size),
-            EXPERIMENTAL(x) => x.clear(flight_id, flight_size),
+            INDEXED(x) => x.clear(flight_id, flight_size),
         }
     }
 
@@ -73,7 +73,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.get(last_block_id, read_bytes_limit_len, task_ids),
-            EXPERIMENTAL(x) => x.get(last_block_id, read_bytes_limit_len, task_ids),
+            INDEXED(x) => x.get(last_block_id, read_bytes_limit_len, task_ids),
         }
     }
 
@@ -83,7 +83,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.spill(),
-            EXPERIMENTAL(x) => x.spill(),
+            INDEXED(x) => x.spill(),
         }
     }
 
@@ -93,7 +93,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.append(blocks, size),
-            EXPERIMENTAL(x) => x.append(blocks, size),
+            INDEXED(x) => x.append(blocks, size),
         }
     }
 
@@ -104,7 +104,7 @@ impl MemoryBuffer for UnifiedBuffer {
     {
         match &self {
             DEFAULT(x) => x.direct_push(blocks),
-            EXPERIMENTAL(x) => x.direct_push(blocks),
+            INDEXED(x) => x.direct_push(blocks),
         }
     }
 }

--- a/riffle-server/src/store/mem/buffer/indexed_buffer.rs
+++ b/riffle-server/src/store/mem/buffer/indexed_buffer.rs
@@ -1,57 +1,84 @@
 use crate::composed_bytes::ComposedBytes;
 use crate::constant::INVALID_BLOCK_ID;
-use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
 use crate::store::mem::buffer::{BufferOptions, BufferSpillResult, MemBlockBatch, MemoryBuffer};
 use crate::store::{Block, DataBytes, DataSegment, PartitionedMemoryData};
 use croaring::Treemap;
-use fastrace::trace;
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::mem;
 use std::sync::Arc;
 
-/// the optimized implementation is from https://github.com/zuston/riffle/pull/564
+/// The indexed implementation is from https://github.com/zuston/riffle/pull/564.
+///
+/// The staging layout is identical to the default buffer (batches of blocks),
+/// so `append` stays an O(1) batch move. The block-position index is built
+/// lazily on the read path: it maps `block_id` to `(batch_idx, offset_in_batch)`
+/// and is caught up incrementally (tracked by `indexed_batches`) only when a
+/// `get` actually needs to locate a cursor inside staging. Data that is spilled
+/// before ever being read this way never pays any indexing cost.
 #[derive(Debug)]
-pub struct OptStagingBufferInternal {
+pub struct IndexedBufferInternal {
     pub total_size: i64,
     pub staging_size: i64,
     pub flight_size: i64,
 
-    pub staging: Vec<Block>,
-    pub batch_boundaries: Vec<usize>, // Track where each batch starts
-    pub block_position_index: HashMap<i64, usize>, // Maps block_id to Vec index
+    pub staging: MemBlockBatch,
+    pub block_position_index: HashMap<i64, (usize, usize)>,
+    // Number of leading staging batches already covered by the index.
+    pub indexed_batches: usize,
 
     pub flight: HashMap<u64, Arc<MemBlockBatch>>,
     pub flight_counter: u64,
 }
 
-impl OptStagingBufferInternal {
+impl IndexedBufferInternal {
     pub fn new() -> Self {
-        OptStagingBufferInternal {
+        IndexedBufferInternal {
             total_size: 0,
             staging_size: 0,
             flight_size: 0,
-            staging: Vec::new(),
-            batch_boundaries: Vec::new(),
+            staging: Default::default(),
             block_position_index: HashMap::new(),
+            indexed_batches: 0,
             flight: Default::default(),
             flight_counter: 0,
         }
     }
+
+    // Index the staging batches appended since the last catch-up.
+    fn catch_up_index(&mut self) {
+        let total_batches = self.staging.len();
+        if self.indexed_batches >= total_batches {
+            return;
+        }
+
+        let pending_blocks: usize = self.staging[self.indexed_batches..]
+            .iter()
+            .map(|batch| batch.len())
+            .sum();
+        self.block_position_index.reserve(pending_blocks);
+
+        for batch_idx in self.indexed_batches..total_batches {
+            for (block_idx, block) in self.staging[batch_idx].iter().enumerate() {
+                self.block_position_index
+                    .insert(block.block_id, (batch_idx, block_idx));
+            }
+        }
+        self.indexed_batches = total_batches;
+    }
 }
 
 #[derive(Debug)]
-pub struct OptStagingMemoryBuffer {
-    buffer: Mutex<OptStagingBufferInternal>,
+pub struct IndexedMemoryBuffer {
+    buffer: Mutex<IndexedBufferInternal>,
 }
 
-impl MemoryBuffer for OptStagingMemoryBuffer {
-    #[trace]
-    fn new(opt: BufferOptions) -> Self {
-        OptStagingMemoryBuffer {
-            buffer: Mutex::new(OptStagingBufferInternal::new()),
+impl MemoryBuffer for IndexedMemoryBuffer {
+    fn new(_options: BufferOptions) -> Self {
+        IndexedMemoryBuffer {
+            buffer: Mutex::new(IndexedBufferInternal::new()),
         }
     }
-    #[trace]
     fn total_size(&self) -> anyhow::Result<i64>
     where
         Self: Send + Sync,
@@ -59,7 +86,6 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
         return Ok(self.buffer.lock().total_size);
     }
 
-    #[trace]
     fn flight_size(&self) -> anyhow::Result<i64>
     where
         Self: Send + Sync,
@@ -67,7 +93,6 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
         return Ok(self.buffer.lock().flight_size);
     }
 
-    #[trace]
     fn staging_size(&self) -> anyhow::Result<i64>
     where
         Self: Send + Sync,
@@ -75,7 +100,6 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
         return Ok(self.buffer.lock().staging_size);
     }
 
-    #[trace]
     fn clear(&self, flight_id: u64, flight_size: u64) -> anyhow::Result<()>
     where
         Self: Send + Sync,
@@ -90,7 +114,6 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
         Ok(())
     }
 
-    #[trace]
     fn get(
         &self,
         last_block_id: i64,
@@ -103,7 +126,14 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
         /// read sequence
         /// 1. from flight (expect: last_block_id not found or last_block_id == -1)
         /// 2. from staging
-        let buffer = self.buffer.lock();
+        let mut buffer = self.buffer.lock();
+
+        // The index catch-up must happen before any block reference is taken,
+        // because it mutates the internal state.
+        if last_block_id != INVALID_BLOCK_ID {
+            buffer.catch_up_index();
+        }
+        let buffer = &*buffer;
 
         let mut read_result = vec![];
         let mut read_len = 0i64;
@@ -141,33 +171,43 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
                 }
             }
 
-            // Handle staging with Vec + index optimization
-            let staging_start_idx = if loop_index == FIRST_ATTEMP && !flight_found {
+            // Handle staging with the block-position index optimization
+            let (start_batch, start_block) = if loop_index == FIRST_ATTEMP && !flight_found {
                 // Try to find position after last_block_id
                 // Always set flight_found = true for the next searching
                 flight_found = true;
-                if let Some(&position) = buffer.block_position_index.get(&last_block_id) {
-                    position + 1
+                if let Some(&(batch_idx, block_idx)) =
+                    buffer.block_position_index.get(&last_block_id)
+                {
+                    (batch_idx, block_idx + 1)
                 } else {
                     // Not found in staging, will handle in fallback
                     continue;
                 }
             } else {
                 // Fallback: read from beginning
-                0
+                (0, 0)
             };
 
-            for block in &buffer.staging[staging_start_idx..] {
-                if read_len >= read_bytes_limit_len {
-                    break;
-                }
-                if let Some(ref expected_task_id) = task_ids {
-                    if !expected_task_id.contains(block.task_attempt_id as u64) {
-                        continue;
+            'staging: for (batch_idx, blocks) in buffer.staging.iter().enumerate().skip(start_batch)
+            {
+                let skip = if batch_idx == start_batch {
+                    start_block
+                } else {
+                    0
+                };
+                for block in &blocks[skip.min(blocks.len())..] {
+                    if read_len >= read_bytes_limit_len {
+                        break 'staging;
                     }
+                    if let Some(ref expected_task_id) = task_ids {
+                        if !expected_task_id.contains(block.task_attempt_id as u64) {
+                            continue;
+                        }
+                    }
+                    read_len += block.length as i64;
+                    read_result.push(block);
                 }
-                read_len += block.length as i64;
-                read_result.push(block);
             }
 
             // // If we found data in first attempt, no need for fallback
@@ -209,39 +249,15 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
     }
 
     // when there is no any staging data, it will return the None
-    #[trace]
     fn spill(&self) -> anyhow::Result<Option<BufferSpillResult>> {
         let mut buffer = self.buffer.lock();
         if buffer.staging_size == 0 {
             return Ok(None);
         }
 
-        // Reconstruct batches from boundaries
-        let mut batches = Vec::new();
-        let mut start = 0;
-        for i in 0..buffer.batch_boundaries.len() {
-            let end = buffer.batch_boundaries[i];
-            if end >= buffer.staging.len() {
-                break;
-            }
-
-            // Find next boundary or use end of staging
-            let next_boundary = if i + 1 < buffer.batch_boundaries.len() {
-                buffer.batch_boundaries[i + 1]
-            } else {
-                buffer.staging.len()
-            };
-
-            batches.push(buffer.staging[start..next_boundary].to_vec());
-            start = next_boundary;
-        }
-
-        let staging: MemBlockBatch = MemBlockBatch(batches);
-
-        // Clear everything
-        buffer.staging.clear();
+        let staging: MemBlockBatch = mem::replace(&mut buffer.staging, Default::default());
         buffer.block_position_index.clear();
-        buffer.batch_boundaries.clear();
+        buffer.indexed_batches = 0;
 
         let staging_ref = Arc::new(staging);
         let flight_id = buffer.flight_counter;
@@ -261,36 +277,76 @@ impl MemoryBuffer for OptStagingMemoryBuffer {
         }))
     }
 
-    #[trace]
     fn append(&self, blocks: Vec<Block>, size: u64) -> anyhow::Result<()> {
         let mut buffer = self.buffer.lock();
-        let current_position = buffer.staging.len();
-        let block_count = blocks.len();
+        buffer.staging.push(blocks);
 
-        // Pre-allocate capacities
-        buffer.staging.reserve(block_count);
-        buffer.block_position_index.reserve(block_count);
-
-        // Record batch boundary
-        if !blocks.is_empty() {
-            buffer.batch_boundaries.push(current_position);
-        }
-
-        for (idx, block) in blocks.into_iter().enumerate() {
-            buffer
-                .block_position_index
-                .insert(block.block_id, current_position + idx);
-            buffer.staging.push(block);
-        }
         buffer.staging_size += size as i64;
         buffer.total_size += size as i64;
         Ok(())
     }
 
     #[cfg(test)]
-    #[trace]
     fn direct_push(&self, blocks: Vec<Block>) -> anyhow::Result<()> {
         let len: u64 = blocks.iter().map(|block| block.length).sum::<i32>() as u64;
         self.append(blocks, len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::test_utils::create_blocks;
+
+    #[test]
+    fn spill_moves_staging_allocation() -> anyhow::Result<()> {
+        let buffer = IndexedMemoryBuffer::new(Default::default());
+        buffer.append(create_blocks(0, 4, 10), 40)?;
+
+        let batch_ptr = buffer.buffer.lock().staging[0].as_ptr();
+        let spill_result = buffer
+            .spill()?
+            .expect("staging blocks should produce a spill result");
+
+        assert_eq!(1, spill_result.blocks.len());
+        assert_eq!(batch_ptr, spill_result.blocks[0].as_ptr());
+        assert!(buffer.buffer.lock().staging.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn lazy_index_catches_up_on_read() -> anyhow::Result<()> {
+        let buffer = IndexedMemoryBuffer::new(Default::default());
+        buffer.append(create_blocks(0, 4, 10), 40)?;
+        buffer.append(create_blocks(4, 4, 10), 40)?;
+
+        // Append alone should not build the index.
+        assert!(buffer.buffer.lock().block_position_index.is_empty());
+
+        // A cursor read inside staging triggers the catch-up.
+        let result = buffer.get(3, 40, None)?;
+        assert_eq!(4, result.shuffle_data_block_segments.len());
+        assert_eq!(3 + 4, result.shuffle_data_block_segments[3].block_id);
+        {
+            let internal = buffer.buffer.lock();
+            assert_eq!(8, internal.block_position_index.len());
+            assert_eq!(2, internal.indexed_batches);
+        }
+
+        // New appends after a catch-up are indexed incrementally on next read.
+        buffer.append(create_blocks(8, 4, 10), 40)?;
+        let result = buffer.get(7, 40, None)?;
+        assert_eq!(4, result.shuffle_data_block_segments.len());
+        assert_eq!(11, result.shuffle_data_block_segments[3].block_id);
+        assert_eq!(12, buffer.buffer.lock().block_position_index.len());
+
+        // Spill drops the index together with staging.
+        buffer.spill()?;
+        {
+            let internal = buffer.buffer.lock();
+            assert!(internal.block_position_index.is_empty());
+            assert_eq!(0, internal.indexed_batches);
+        }
+        Ok(())
     }
 }

--- a/riffle-server/src/store/mem/tracking.rs
+++ b/riffle-server/src/store/mem/tracking.rs
@@ -77,7 +77,7 @@ mod tests {
     use super::*;
     use crate::app_manager::partition_identifier::PartitionUId;
     use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-    use crate::store::mem::buffer::opt_buffer::OptStagingMemoryBuffer;
+    use crate::store::mem::buffer::indexed_buffer::IndexedMemoryBuffer;
     use crate::store::mem::buffer::MemoryBuffer;
     use crate::store::test_utils::create_blocks;
     use crate::store::Block;
@@ -141,14 +141,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_merge_with_opt_buffers() {
+    async fn test_merge_with_indexed_buffers() {
         let manager = BufferSizeTracking::new();
         let mut buffers = HashMap::new();
 
-        // Create test buffers with OptStagingMemoryBuffer
+        // Create test buffers with IndexedMemoryBuffer
         for i in 0..5 {
             let uid = PartitionUId::new(&Default::default(), i, 0);
-            let buffer = Arc::new(OptStagingMemoryBuffer::new(Default::default()));
+            let buffer = Arc::new(IndexedMemoryBuffer::new(Default::default()));
 
             // Add data to buffer
             let blocks = create_blocks(i * 10, 2, 10);

--- a/riffle-server/src/store/memory.rs
+++ b/riffle-server/src/store/memory.rs
@@ -38,7 +38,6 @@ use crate::ddashmap::DDashMap;
 use crate::runtime::manager::RuntimeManager;
 use crate::store::mem::budget::MemoryBudget;
 use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-use crate::store::mem::buffer::opt_buffer::OptStagingMemoryBuffer;
 use crate::store::mem::buffer::{BufferOptions, BufferType, MemoryBuffer};
 use crate::store::mem::capacity::CapacitySnapshot;
 use crate::store::mem::ticket::TicketManager;
@@ -445,7 +444,7 @@ mod test {
     use crate::app_manager::purge_event::PurgeReason;
     use crate::runtime::manager::RuntimeManager;
     use crate::store::mem::buffer::default_buffer::DefaultMemoryBuffer;
-    use crate::store::mem::buffer::opt_buffer::OptStagingMemoryBuffer;
+    use crate::store::mem::buffer::indexed_buffer::IndexedMemoryBuffer;
     use crate::store::mem::buffer::MemoryBuffer;
     use anyhow::Result;
     use croaring::Treemap;
@@ -620,7 +619,7 @@ mod test {
     #[test]
     fn test_read_buffer_in_flight() {
         run_test_read_buffer_in_flight::<DefaultMemoryBuffer>();
-        run_test_read_buffer_in_flight::<OptStagingMemoryBuffer>();
+        run_test_read_buffer_in_flight::<IndexedMemoryBuffer>();
     }
 
     async fn get_data_with_last_block_id<B: MemoryBuffer + Send + Sync + 'static>(
@@ -700,7 +699,7 @@ mod test {
     #[test]
     fn test_allocated_and_purge_for_memory() {
         run_test_allocated_and_purge_for_memory::<DefaultMemoryBuffer>();
-        run_test_allocated_and_purge_for_memory::<OptStagingMemoryBuffer>();
+        run_test_allocated_and_purge_for_memory::<IndexedMemoryBuffer>();
     }
 
     fn run_test_timeout_ticket_releases_allocated_for_configured_store<
@@ -726,7 +725,7 @@ mod test {
     #[test]
     fn test_timeout_ticket_releases_allocated_for_configured_store() {
         run_test_timeout_ticket_releases_allocated_for_configured_store::<DefaultMemoryBuffer>();
-        run_test_timeout_ticket_releases_allocated_for_configured_store::<OptStagingMemoryBuffer>();
+        run_test_timeout_ticket_releases_allocated_for_configured_store::<IndexedMemoryBuffer>();
     }
 
     fn run_test_purge<B: MemoryBuffer + Send + Sync + 'static>() -> Result<()> {
@@ -809,7 +808,7 @@ mod test {
     #[test]
     fn test_purge() {
         run_test_purge::<DefaultMemoryBuffer>();
-        run_test_purge::<OptStagingMemoryBuffer>();
+        run_test_purge::<IndexedMemoryBuffer>();
     }
 
     fn run_test_put_and_get_for_memory<B: MemoryBuffer + Send + Sync + 'static>() {
@@ -858,7 +857,7 @@ mod test {
     #[test]
     fn test_put_and_get_for_memory() {
         run_test_put_and_get_for_memory::<DefaultMemoryBuffer>();
-        run_test_put_and_get_for_memory::<OptStagingMemoryBuffer>();
+        run_test_put_and_get_for_memory::<IndexedMemoryBuffer>();
     }
 
     fn run_test_block_id_filter_for_memory<B: MemoryBuffer + Send + Sync + 'static>() {
@@ -930,7 +929,7 @@ mod test {
     #[test]
     fn test_block_id_filter_for_memory() {
         run_test_block_id_filter_for_memory::<DefaultMemoryBuffer>();
-        run_test_block_id_filter_for_memory::<OptStagingMemoryBuffer>();
+        run_test_block_id_filter_for_memory::<IndexedMemoryBuffer>();
     }
 
     fn run_test_memory_store_operation_with_buffer_size_tracking<
@@ -992,6 +991,6 @@ mod test {
     #[test]
     fn test_memory_store_operation_with_buffer_size_tracking() {
         run_test_memory_store_operation_with_buffer_size_tracking::<DefaultMemoryBuffer>();
-        run_test_memory_store_operation_with_buffer_size_tracking::<OptStagingMemoryBuffer>();
+        run_test_memory_store_operation_with_buffer_size_tracking::<IndexedMemoryBuffer>();
     }
 }


### PR DESCRIPTION
### Performance: indexed vs default

Measured with `cargo bench --bench memory_buffer` (256-byte blocks, appended in batches of 128).

**append** (whole workload; lower is better)

| Blocks | default | indexed |
|--------|---------|---------|
| 1,024  | ~273 ns | ~290 ns |
| 16,384 | ~3.27 us | ~3.14 us |

**spill**

| Blocks | default | indexed |
|--------|---------|---------|
| 1,024  | ~132 ns | ~149 ns |
| 16,384 | ~248 ns | ~245 ns |


**get** (read 256 blocks / 64 KiB from staging; lower is better)

| Blocks | Cursor  | default | indexed | Speedup |
|--------|---------|---------|---------|---------|
| 1,024  | start   | 7.7 us  | 7.6 us  | 1.0x |
| 1,024  | middle  | 8.5 us  | 7.7 us  | 1.1x |
| 1,024  | tail    | 9.1 us  | 7.7 us  | 1.2x |
| 1,024  | missing | 9.5 us  | 7.7 us  | 1.2x |
| 16,384 | start   | 8.2 us  | 7.7 us  | 1.1x |
| 16,384 | middle  | 22.8 us | 7.8 us  | **2.9x** |
| 16,384 | tail    | 38.8 us | 7.4 us  | **5.2x** |
| 16,384 | missing | 38.8 us | 7.7 us  | **5.1x** |

The default buffer's cursor lookup degrades linearly with staging size, while the indexed buffer stays flat (~7.7 us) regardless of buffer size and cursor position.
