### PR TITLE
feat(urpc): add pluggable `io_uring` net engine

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,12 @@ jobs:
             artifact_path: target-docker/release/riffle-server
             docker_compose: dev/anolisos8/amd64/docker-compose.yml
             component: riffle-server
+          - name: linux-amd64-anolisos8-hdfs-native
+            os: ubuntu-22.04
+            build_command: RIFFLE_HDFS_FEATURE=hdfs docker compose -f dev/anolisos8/amd64/docker-compose.yml up
+            artifact_path: target-docker/release/riffle-server
+            docker_compose: dev/anolisos8/amd64/docker-compose.yml
+            component: riffle-server
 
     steps:
       - name: Remove unnecessary files (Linux only)

--- a/dev/anolisos8/amd64/docker-compose.yml
+++ b/dev/anolisos8/amd64/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       - ./../../../target-docker:/R1/target:rw
     #    environment:
     #      RUSTFLAGS: "-C target-cpu=skylake"
-    command: "bash -c 'source ~/.bashrc && cd /R1 && cargo build --release -p riffle-server --no-default-features --features hdrs,logforth,jemalloc,io-uring && cargo build --release -p riffle-coordinator && cargo build --release -p riffle-ctl'"
+    command: "bash -c 'source ~/.bashrc && cd /R1 && cargo build --release -p riffle-server --no-default-features --features ${RIFFLE_HDFS_FEATURE:-hdrs},logforth,jemalloc,io-uring && cargo build --release -p riffle-coordinator && cargo build --release -p riffle-ctl'"

--- a/riffle-server/Cargo.toml
+++ b/riffle-server/Cargo.toml
@@ -176,3 +176,8 @@ harness = false
 [[bench]]
 name = "urpc_streaming_parse"
 harness = false
+
+[[bench]]
+name = "urpc_net_engine"
+harness = false
+required-features = ["io-uring"]

--- a/riffle-server/benches/urpc_net_engine.rs
+++ b/riffle-server/benches/urpc_net_engine.rs
@@ -1,0 +1,321 @@
+//! Throughput microbench comparing the default tokio based urpc network
+//! stack against the pluggable io_uring net engine.
+//!
+//! Both servers speak the same wire protocol and apply the same echo
+//! semantics: parse an inbound `SendShuffleData` frame and answer with an
+//! empty `RpcResponse`. The only difference is the network engine.
+//!
+//! Run with:
+//!   cargo bench --bench urpc_net_engine --features io-uring
+//!
+//! Env knobs: BENCH_DURATION_SECS, BENCH_SERVER_THREADS, BENCH_CONNS,
+//! BENCH_PIPELINE.
+
+use anyhow::Result;
+use bytes::{BufMut, Bytes, BytesMut};
+use riffle_server::urpc::command::RpcResponseCommand;
+use riffle_server::urpc::connection::Connection;
+use riffle_server::urpc::frame::{Frame, MessageType};
+use riffle_server::urpc::uring::{Responder, UringServerConfig, UringUrpcServer};
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// header(9) + request_id(8) + status(4) + empty msg len(4)
+const RPC_RESPONSE_WIRE_LEN: usize = 25;
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn put_string(buf: &mut BytesMut, value: &str) {
+    buf.put_i32(value.len() as i32);
+    buf.put_slice(value.as_bytes());
+}
+
+fn build_send_shuffle_data_frame(request_id: i64, payload_len: usize) -> Bytes {
+    let payload = vec![(request_id % 251) as u8; payload_len];
+    let mut body = BytesMut::new();
+    body.put_i64(request_id);
+    put_string(&mut body, "app-bench");
+    body.put_i32(7);
+    body.put_i64(99);
+    body.put_i32(1); // partition batch size
+    body.put_i32(11); // partition id
+    body.put_i32(1); // block batch size
+    body.put_i32(11); // pid
+    body.put_i64(1234); // block id
+    body.put_i32(payload.len() as i32); // length
+    body.put_i32(7); // shuffle id
+    body.put_i64(88); // crc
+    body.put_i64(9001); // task attempt id
+    body.put_i32(payload.len() as i32);
+    body.put_slice(&payload);
+    body.put_i32(0); // shuffle servers
+    body.put_i32(payload.len() as i32); // uncompress length
+    body.put_i64(0); // free mem
+    body.put_i64(123456); // timestamp
+
+    let mut frame = BytesMut::with_capacity(9 + body.len());
+    frame.put_i32(0);
+    frame.put_u8(MessageType::SendShuffleData as u8);
+    frame.put_i32(body.len() as i32);
+    frame.extend_from_slice(&body);
+    frame.freeze()
+}
+
+fn echo_response(frame: Frame) -> Frame {
+    match frame {
+        Frame::SendShuffleData(req) => {
+            Frame::RpcResponse(RpcResponseCommand::new(req.request_id(), 0, String::new()))
+        }
+        other => panic!("unexpected frame in bench: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Default engine: the existing tokio network stack (Connection + Frame).
+// Mirrors `rpc.rs`: per-core std threads, each with a current_thread runtime
+// and a SO_REUSEPORT listener.
+// ---------------------------------------------------------------------------
+
+struct TokioEchoServer {
+    addr: SocketAddr,
+    stops: Vec<tokio::sync::oneshot::Sender<()>>,
+    joins: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl TokioEchoServer {
+    fn start(threads: usize) -> Result<Self> {
+        let first = build_reuseport_listener("127.0.0.1:0".parse()?)?;
+        let addr = first.local_addr()?;
+
+        let mut listeners = vec![first];
+        for _ in 1..threads {
+            listeners.push(build_reuseport_listener(addr)?);
+        }
+
+        let mut stops = Vec::new();
+        let mut joins = Vec::new();
+        for (i, listener) in listeners.into_iter().enumerate() {
+            let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+            stops.push(stop_tx);
+            let join = std::thread::Builder::new()
+                .name(format!("bench-tokio-{i}"))
+                .spawn(move || {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap();
+                    rt.block_on(async move {
+                        listener.set_nonblocking(true).unwrap();
+                        let listener = TcpListener::from_std(listener).unwrap();
+                        loop {
+                            let socket = tokio::select! {
+                                accepted = listener.accept() => match accepted {
+                                    Ok((socket, _)) => socket,
+                                    Err(_) => break,
+                                },
+                                _ = &mut stop_rx => break,
+                            };
+                            let sock_ref = socket2::SockRef::from(&socket);
+                            let _ = sock_ref.set_keepalive(true);
+                            let _ = sock_ref.set_nodelay(true);
+                            tokio::spawn(async move {
+                                // The default urpc server network path:
+                                // streaming parse enabled + vectored writes.
+                                let mut conn = Connection::new(socket, true);
+                                loop {
+                                    match conn.read_frame().await {
+                                        Ok(Some(frame)) => {
+                                            let resp = echo_response(frame);
+                                            if conn.write_frame(&resp).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                        _ => break,
+                                    }
+                                }
+                            });
+                        }
+                    });
+                })?;
+            joins.push(join);
+        }
+        Ok(Self { addr, stops, joins })
+    }
+
+    fn shutdown(self) {
+        for stop in self.stops {
+            let _ = stop.send(());
+        }
+        for join in self.joins {
+            let _ = join.join();
+        }
+    }
+}
+
+fn build_reuseport_listener(addr: SocketAddr) -> Result<std::net::TcpListener> {
+    let sock = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)?;
+    sock.set_reuse_address(true)?;
+    sock.set_reuse_port(true)?;
+    sock.bind(&addr.into())?;
+    sock.listen(8192)?;
+    Ok(sock.into())
+}
+
+// ---------------------------------------------------------------------------
+// Load generation
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+struct Case {
+    name: &'static str,
+    payload_len: usize,
+    pipeline: usize,
+}
+
+struct CaseResult {
+    rps: f64,
+    mbps: f64,
+}
+
+fn run_case(addr: SocketAddr, case: Case, conns: usize, duration: Duration) -> Result<CaseResult> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(conns.min(8))
+        .enable_all()
+        .build()?;
+
+    // One pipelined batch, pre-serialized once.
+    let mut batch = BytesMut::new();
+    for id in 0..case.pipeline {
+        batch.extend_from_slice(&build_send_shuffle_data_frame(id as i64, case.payload_len));
+    }
+    let batch = batch.freeze();
+
+    let total_responses = Arc::new(AtomicU64::new(0));
+    let result = rt.block_on(async {
+        let warmup = Duration::from_millis(500);
+        let deadline = Instant::now() + warmup + duration;
+        let measure_start = Instant::now() + warmup;
+
+        let mut tasks = Vec::new();
+        for _ in 0..conns {
+            let batch = batch.clone();
+            let total_responses = total_responses.clone();
+            tasks.push(tokio::spawn(async move {
+                let mut stream = TcpStream::connect(addr).await?;
+                stream.set_nodelay(true)?;
+                let mut resp_buf = vec![0u8; RPC_RESPONSE_WIRE_LEN * case.pipeline];
+                let pipeline = case.pipeline as u64;
+                loop {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        break;
+                    }
+                    stream.write_all(&batch).await?;
+                    stream.read_exact(&mut resp_buf).await?;
+                    // Sanity check the first response header.
+                    assert_eq!(MessageType::RpcResponse as u8, resp_buf[4]);
+                    if now >= measure_start {
+                        total_responses.fetch_add(pipeline, Ordering::Relaxed);
+                    }
+                }
+                anyhow::Ok(())
+            }));
+        }
+        for task in tasks {
+            task.await??;
+        }
+        anyhow::Ok(())
+    });
+    result?;
+
+    let total = total_responses.load(Ordering::Relaxed) as f64;
+    let secs = duration.as_secs_f64();
+    let rps = total / secs;
+    let mbps = rps * case.payload_len as f64 / 1024.0 / 1024.0;
+    Ok(CaseResult { rps, mbps })
+}
+
+fn main() -> Result<()> {
+    let duration = Duration::from_secs(env_usize("BENCH_DURATION_SECS", 3) as u64);
+    let server_threads = env_usize("BENCH_SERVER_THREADS", 2);
+    let conns = env_usize("BENCH_CONNS", 8);
+
+    let cases = [
+        Case {
+            name: "block=1KB",
+            payload_len: 1024,
+            pipeline: env_usize("BENCH_PIPELINE", 64),
+        },
+        Case {
+            name: "block=64KB",
+            payload_len: 64 * 1024,
+            pipeline: 16,
+        },
+        Case {
+            name: "block=512KB",
+            payload_len: 512 * 1024,
+            pipeline: 4,
+        },
+    ];
+
+    println!(
+        "urpc net engine bench: server_threads={}, conns={}, duration={:?}",
+        server_threads, conns, duration
+    );
+    println!(
+        "{:<14} {:>14} {:>12} {:>14} {:>12} {:>9}",
+        "case", "tokio rps", "tokio MB/s", "uring rps", "uring MB/s", "speedup"
+    );
+
+    let mut all_pass = true;
+    for case in cases {
+        let tokio_server = TokioEchoServer::start(server_threads)?;
+        let tokio_result = run_case(tokio_server.addr, case, conns, duration)?;
+        tokio_server.shutdown();
+
+        let uring_server = UringUrpcServer::start(
+            "127.0.0.1:0".parse()?,
+            server_threads,
+            UringServerConfig::default(),
+            |_| {
+                |frame: Frame, responder: &mut Responder<'_>| {
+                    let resp = echo_response(frame);
+                    responder.respond(&resp).unwrap();
+                }
+            },
+        )?;
+        let uring_result = run_case(uring_server.local_addr(), case, conns, duration)?;
+        uring_server.shutdown();
+
+        let speedup = uring_result.rps / tokio_result.rps;
+        if speedup <= 1.0 {
+            all_pass = false;
+        }
+        println!(
+            "{:<14} {:>14.0} {:>12.1} {:>14.0} {:>12.1} {:>8.2}x",
+            case.name,
+            tokio_result.rps,
+            tokio_result.mbps,
+            uring_result.rps,
+            uring_result.mbps,
+            speedup
+        );
+        std::io::stdout().flush()?;
+    }
+
+    println!(
+        "\nresult: uring engine {} the default tokio engine on all cases",
+        if all_pass { "BEATS" } else { "DOES NOT BEAT" }
+    );
+    Ok(())
+}

--- a/riffle-server/benches/urpc_net_engine.rs
+++ b/riffle-server/benches/urpc_net_engine.rs
@@ -9,13 +9,14 @@
 //!   cargo bench --bench urpc_net_engine --features io-uring
 //!
 //! Env knobs: BENCH_DURATION_SECS, BENCH_SERVER_THREADS, BENCH_CONNS,
-//! BENCH_PIPELINE.
+//! BENCH_PIPELINE (overrides the 1 KiB case only).
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use riffle_server::urpc::command::RpcResponseCommand;
 use riffle_server::urpc::connection::Connection;
 use riffle_server::urpc::frame::{Frame, MessageType};
+use riffle_server::urpc::uring::encode::parse_request_frame;
 use riffle_server::urpc::uring::{Responder, UringServerConfig, UringUrpcServer};
 use std::io::Write;
 use std::net::SocketAddr;
@@ -36,39 +37,95 @@ fn env_usize(key: &str, default: usize) -> usize {
 }
 
 fn put_string(buf: &mut BytesMut, value: &str) {
-    buf.put_i32(value.len() as i32);
+    buf.put_i32(i32::try_from(value.len()).expect("string length must fit in i32"));
     buf.put_slice(value.as_bytes());
 }
 
-fn build_send_shuffle_data_frame(request_id: i64, payload_len: usize) -> Bytes {
-    let payload = vec![(request_id % 251) as u8; payload_len];
-    let mut body = BytesMut::new();
+fn build_send_shuffle_data_frame(request_id: i64, case: Case) -> Bytes {
+    let partition_count =
+        i32::try_from(case.partition_count).expect("partition count must fit in i32");
+    let blocks_per_partition =
+        i32::try_from(case.blocks_per_partition).expect("block count must fit in i32");
+    let block_len = i32::try_from(case.block_len).expect("block length must fit in i32");
+    let payload = vec![(request_id % 251) as u8; case.block_len];
+    let mut body = BytesMut::with_capacity(case.request_payload_len());
     body.put_i64(request_id);
     put_string(&mut body, "app-bench");
     body.put_i32(7);
     body.put_i64(99);
-    body.put_i32(1); // partition batch size
-    body.put_i32(11); // partition id
-    body.put_i32(1); // block batch size
-    body.put_i32(11); // pid
-    body.put_i64(1234); // block id
-    body.put_i32(payload.len() as i32); // length
-    body.put_i32(7); // shuffle id
-    body.put_i64(88); // crc
-    body.put_i64(9001); // task attempt id
-    body.put_i32(payload.len() as i32);
-    body.put_slice(&payload);
-    body.put_i32(0); // shuffle servers
-    body.put_i32(payload.len() as i32); // uncompress length
-    body.put_i64(0); // free mem
+    body.put_i32(partition_count);
+
+    let blocks_per_request =
+        i64::try_from(case.blocks_per_request()).expect("block count must fit in i64");
+    for partition_index in 0..case.partition_count {
+        let partition_id = i32::try_from(partition_index).expect("partition id must fit in i32");
+        body.put_i32(partition_id);
+        body.put_i32(blocks_per_partition);
+
+        for block_index in 0..case.blocks_per_partition {
+            let block_offset = partition_index
+                .checked_mul(case.blocks_per_partition)
+                .and_then(|offset| offset.checked_add(block_index))
+                .expect("block offset must fit in usize");
+            let block_offset = i64::try_from(block_offset).expect("block offset must fit in i64");
+            let block_id = request_id
+                .checked_mul(blocks_per_request)
+                .and_then(|base| base.checked_add(block_offset))
+                .expect("block id must fit in i64");
+
+            body.put_i32(partition_id); // pid
+            body.put_i64(block_id);
+            body.put_i32(block_len);
+            body.put_i32(7); // shuffle id
+            body.put_i64(88); // crc
+            body.put_i64(9001); // task attempt id
+            body.put_i32(block_len);
+            body.put_slice(&payload);
+            body.put_i32(0); // shuffle servers
+            body.put_i32(block_len); // uncompress length
+            body.put_i64(0); // free mem
+        }
+    }
     body.put_i64(123456); // timestamp
 
     let mut frame = BytesMut::with_capacity(9 + body.len());
     frame.put_i32(0);
     frame.put_u8(MessageType::SendShuffleData as u8);
-    frame.put_i32(body.len() as i32);
+    frame.put_i32(i32::try_from(body.len()).expect("request body length must fit in i32"));
     frame.extend_from_slice(&body);
     frame.freeze()
+}
+
+fn validate_case_frame(case: Case) -> Result<()> {
+    ensure!(case.block_len > 0, "case {} has an empty block", case.name);
+    ensure!(
+        case.partition_count > 0,
+        "case {} has no partitions",
+        case.name
+    );
+    ensure!(
+        case.blocks_per_partition > 0,
+        "case {} has no blocks",
+        case.name
+    );
+    ensure!(
+        case.pipeline > 0,
+        "case {} has an empty pipeline",
+        case.name
+    );
+
+    let frame = parse_request_frame(build_send_shuffle_data_frame(0, case))?;
+    let Frame::SendShuffleData(request) = frame else {
+        anyhow::bail!("case {} did not produce SendShuffleData", case.name);
+    };
+    ensure!(
+        request.data_len() == case.request_payload_len(),
+        "case {} payload mismatch: expected {}, parsed {}",
+        case.name,
+        case.request_payload_len(),
+        request.data_len()
+    );
+    Ok(())
 }
 
 fn echo_response(frame: Frame) -> Frame {
@@ -178,13 +235,29 @@ fn build_reuseport_listener(addr: SocketAddr) -> Result<std::net::TcpListener> {
 #[derive(Clone, Copy)]
 struct Case {
     name: &'static str,
-    payload_len: usize,
+    block_len: usize,
+    partition_count: usize,
+    blocks_per_partition: usize,
     pipeline: usize,
+}
+
+impl Case {
+    fn blocks_per_request(self) -> usize {
+        self.partition_count
+            .checked_mul(self.blocks_per_partition)
+            .expect("blocks per request must fit in usize")
+    }
+
+    fn request_payload_len(self) -> usize {
+        self.blocks_per_request()
+            .checked_mul(self.block_len)
+            .expect("request payload length must fit in usize")
+    }
 }
 
 struct CaseResult {
     rps: f64,
-    mbps: f64,
+    mib_per_sec: f64,
 }
 
 fn run_case(addr: SocketAddr, case: Case, conns: usize, duration: Duration) -> Result<CaseResult> {
@@ -196,7 +269,8 @@ fn run_case(addr: SocketAddr, case: Case, conns: usize, duration: Duration) -> R
     // One pipelined batch, pre-serialized once.
     let mut batch = BytesMut::new();
     for id in 0..case.pipeline {
-        batch.extend_from_slice(&build_send_shuffle_data_frame(id as i64, case.payload_len));
+        let request_id = i64::try_from(id).expect("request id must fit in i64");
+        batch.extend_from_slice(&build_send_shuffle_data_frame(request_id, case));
     }
     let batch = batch.freeze();
 
@@ -214,7 +288,7 @@ fn run_case(addr: SocketAddr, case: Case, conns: usize, duration: Duration) -> R
                 let mut stream = TcpStream::connect(addr).await?;
                 stream.set_nodelay(true)?;
                 let mut resp_buf = vec![0u8; RPC_RESPONSE_WIRE_LEN * case.pipeline];
-                let pipeline = case.pipeline as u64;
+                let pipeline = u64::try_from(case.pipeline).expect("pipeline must fit in u64");
                 loop {
                     let now = Instant::now();
                     if now >= deadline {
@@ -241,30 +315,48 @@ fn run_case(addr: SocketAddr, case: Case, conns: usize, duration: Duration) -> R
     let total = total_responses.load(Ordering::Relaxed) as f64;
     let secs = duration.as_secs_f64();
     let rps = total / secs;
-    let mbps = rps * case.payload_len as f64 / 1024.0 / 1024.0;
-    Ok(CaseResult { rps, mbps })
+    let mib_per_sec = rps * case.request_payload_len() as f64 / 1024.0 / 1024.0;
+    Ok(CaseResult { rps, mib_per_sec })
 }
 
 fn main() -> Result<()> {
-    let duration = Duration::from_secs(env_usize("BENCH_DURATION_SECS", 3) as u64);
+    let duration_secs = env_usize("BENCH_DURATION_SECS", 3);
     let server_threads = env_usize("BENCH_SERVER_THREADS", 2);
     let conns = env_usize("BENCH_CONNS", 8);
+    ensure!(duration_secs > 0, "BENCH_DURATION_SECS must be positive");
+    ensure!(server_threads > 0, "BENCH_SERVER_THREADS must be positive");
+    ensure!(conns > 0, "BENCH_CONNS must be positive");
+    let duration = Duration::from_secs(duration_secs as u64);
 
     let cases = [
         Case {
             name: "block=1KB",
-            payload_len: 1024,
+            block_len: 1024,
+            partition_count: 1,
+            blocks_per_partition: 1,
             pipeline: env_usize("BENCH_PIPELINE", 64),
         },
         Case {
             name: "block=64KB",
-            payload_len: 64 * 1024,
+            block_len: 64 * 1024,
+            partition_count: 1,
+            blocks_per_partition: 1,
             pipeline: 16,
         },
         Case {
             name: "block=512KB",
-            payload_len: 512 * 1024,
+            block_len: 512 * 1024,
+            partition_count: 1,
+            blocks_per_partition: 1,
             pipeline: 4,
+        },
+        // Production shape: one request carries 500 blocks across 500 partitions.
+        Case {
+            name: "prod=500x10KB",
+            block_len: 10 * 1024,
+            partition_count: 500,
+            blocks_per_partition: 1,
+            pipeline: 1,
         },
     ];
 
@@ -274,11 +366,13 @@ fn main() -> Result<()> {
     );
     println!(
         "{:<14} {:>14} {:>12} {:>14} {:>12} {:>9}",
-        "case", "tokio rps", "tokio MB/s", "uring rps", "uring MB/s", "speedup"
+        "case", "tokio rps", "tokio MiB/s", "uring rps", "uring MiB/s", "speedup"
     );
 
-    let mut all_pass = true;
+    let mut uring_wins = 0;
     for case in cases {
+        validate_case_frame(case)?;
+
         let tokio_server = TokioEchoServer::start(server_threads)?;
         let tokio_result = run_case(tokio_server.addr, case, conns, duration)?;
         tokio_server.shutdown();
@@ -298,24 +392,25 @@ fn main() -> Result<()> {
         uring_server.shutdown();
 
         let speedup = uring_result.rps / tokio_result.rps;
-        if speedup <= 1.0 {
-            all_pass = false;
+        if speedup > 1.0 {
+            uring_wins += 1;
         }
         println!(
             "{:<14} {:>14.0} {:>12.1} {:>14.0} {:>12.1} {:>8.2}x",
             case.name,
             tokio_result.rps,
-            tokio_result.mbps,
+            tokio_result.mib_per_sec,
             uring_result.rps,
-            uring_result.mbps,
+            uring_result.mib_per_sec,
             speedup
         );
         std::io::stdout().flush()?;
     }
 
     println!(
-        "\nresult: uring engine {} the default tokio engine on all cases",
-        if all_pass { "BEATS" } else { "DOES NOT BEAT" }
+        "\nresult: uring engine beats the default tokio engine on {}/{} cases",
+        uring_wins,
+        cases.len()
     );
     Ok(())
 }

--- a/riffle-server/src/config.rs
+++ b/riffle-server/src/config.rs
@@ -517,6 +517,20 @@ pub struct UrpcConfig {
 
     #[serde(default)]
     pub write_mode: UrpcWriteMode,
+
+    /// The pluggable network engine serving the urpc protocol.
+    /// URING requires the `io-uring` cargo feature on linux, otherwise it
+    /// falls back to TOKIO with a warning.
+    #[serde(default)]
+    pub net_engine: UrpcNetEngine,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum UrpcNetEngine {
+    #[default]
+    TOKIO,
+    URING,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/riffle-server/src/rpc.rs
+++ b/riffle-server/src/rpc.rs
@@ -61,6 +61,24 @@ impl DefaultRpcService {
         app_manager_ref: AppManagerRef,
     ) -> Result<()> {
         let urpc_port = config.urpc_port.unwrap();
+
+        let net_engine = config
+            .urpc_config
+            .as_ref()
+            .map(|c| c.net_engine)
+            .unwrap_or_default();
+        if matches!(net_engine, crate::config::UrpcNetEngine::URING) {
+            #[cfg(all(feature = "io-uring", target_os = "linux"))]
+            {
+                return Self::_start_urpc_uring(config, runtime_manager, tx, app_manager_ref);
+            }
+            #[cfg(not(all(feature = "io-uring", target_os = "linux")))]
+            log::warn!(
+                "urpc net_engine=URING requires the io-uring feature on linux, \
+                 falling back to the TOKIO engine."
+            );
+        }
+
         info!("Starting urpc server with port:[{}] ......", urpc_port);
 
         async fn shutdown(mut rx: Receiver<()>) -> Result<()> {
@@ -105,6 +123,52 @@ impl DefaultRpcService {
                 });
             }
         }
+
+        Ok(())
+    }
+
+    /// Serves urpc with the pluggable io_uring net engine: per-core engine
+    /// threads own all socket I/O, while the command processing runs on the
+    /// dispatch tokio runtime and completes responses asynchronously.
+    #[cfg(all(feature = "io-uring", target_os = "linux"))]
+    fn _start_urpc_uring(
+        config: &Config,
+        runtime_manager: RuntimeManager,
+        tx: Sender<()>,
+        app_manager_ref: AppManagerRef,
+    ) -> Result<()> {
+        use crate::urpc::uring::{AppCommandBridgeHandler, UringServerConfig, UringUrpcServer};
+
+        let urpc_port = config.urpc_port.unwrap();
+        let threads = URPC_PARALLELISM.get();
+        info!(
+            "Starting urpc server with the io_uring net engine. port:[{}], threads:[{}] ......",
+            urpc_port, threads
+        );
+
+        let mut engine_config = UringServerConfig::default();
+        engine_config.bind_cores = core_affinity::get_core_ids()
+            .map(|ids| ids.into_iter().map(|core| core.id as u32).collect());
+
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), urpc_port);
+        let app_manager = app_manager_ref.clone();
+        let dispatch_runtime = runtime_manager.dispatch_runtime.clone();
+        let server = UringUrpcServer::start(addr, threads, engine_config, move |_| {
+            AppCommandBridgeHandler::new(app_manager.clone(), dispatch_runtime.clone())
+        })?;
+
+        let mut rx = tx.subscribe();
+        std::thread::Builder::new()
+            .name("urpc-uring-shutdown".to_string())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let _ = rt.block_on(rx.recv());
+                info!("Shutting down the urpc io_uring net engine...");
+                server.shutdown();
+            })?;
 
         Ok(())
     }

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -48,45 +48,54 @@ impl Command {
         }
     }
 
+    /// Computes the response frame of this command. This is the net-engine
+    /// agnostic part shared by the default tokio server and the io_uring
+    /// engine bridge.
+    pub async fn process(self, app_manager_ref: AppManagerRef) -> Result<Frame> {
+        match self {
+            Command::Send(req) => {
+                req.process(app_manager_ref)
+                    .instrument_await("applying the command of [Send]")
+                    .await
+            }
+            Command::GetMem(req) => {
+                req.process(app_manager_ref)
+                    .instrument_await("applying the command of [GetMemory]")
+                    .await
+            }
+            Command::GetLocalIndex(req) => {
+                req.process(app_manager_ref)
+                    .instrument_await("applying the command of [GetLocalIndex]")
+                    .await
+            }
+            Command::GetLocalData(req) => {
+                req.process(app_manager_ref)
+                    .instrument_await("applying the command of [GetLocalData]")
+                    .await
+            }
+            Command::GetLocalDataV2(req) => {
+                req.process(app_manager_ref)
+                    .instrument_await("applying the command of [GetLocalDataV2]")
+                    .await
+            }
+            Command::GetLocalDataV3(req) => {
+                req.process(app_manager_ref)
+                    .instrument_await("applying the command of [GetLocalDataV3]")
+                    .await
+            }
+        }
+    }
+
     pub async fn apply(
         self,
         app_manager_ref: AppManagerRef,
         conn: &mut Connection,
-        shutdown: &mut Shutdown,
+        _shutdown: &mut Shutdown,
     ) -> Result<()> {
-        match self {
-            Command::Send(req) => {
-                req.apply(app_manager_ref, conn, shutdown)
-                    .instrument_await("applying the command of [Send]")
-                    .await?
-            }
-            Command::GetMem(req) => {
-                req.apply(app_manager_ref, conn, shutdown)
-                    .instrument_await("applying the command of [GetMemory]")
-                    .await?
-            }
-            Command::GetLocalIndex(req) => {
-                req.apply(app_manager_ref, conn, shutdown)
-                    .instrument_await("applying the command of [GetLocalIndex]")
-                    .await?
-            }
-            Command::GetLocalData(req) => {
-                req.apply(app_manager_ref, conn, shutdown)
-                    .instrument_await("applying the command of [GetLocalData]")
-                    .await?
-            }
-            Command::GetLocalDataV2(req) => {
-                req.apply(app_manager_ref, conn, shutdown)
-                    .instrument_await("applying the command of [GetLocalDataV2]")
-                    .await?
-            }
-            Command::GetLocalDataV3(req) => {
-                req.apply(app_manager_ref, conn, shutdown)
-                    .instrument_await("applying the command of [GetLocalDataV3]")
-                    .await?
-            }
-            _ => {}
-        }
+        let frame = self.process(app_manager_ref).await?;
+        conn.write_frame(&frame)
+            .instrument_await("writing the response...")
+            .await?;
         Ok(())
     }
 }
@@ -104,12 +113,7 @@ pub struct GetMemoryDataRequestCommand {
 }
 
 impl GetMemoryDataRequestCommand {
-    pub(crate) async fn apply(
-        &self,
-        app_manager_ref: AppManagerRef,
-        conn: &mut Connection,
-        shutdown: &mut Shutdown,
-    ) -> Result<()> {
+    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -122,15 +126,11 @@ impl GetMemoryDataRequestCommand {
 
         let app = app_manager_ref.get_app(&application_id);
         if app.is_none() {
-            let response = RpcResponseCommand {
+            return Ok(Frame::RpcResponse(RpcResponseCommand {
                 request_id,
                 status_code: StatusCode::NO_REGISTER.into(),
                 ret_msg: "No such app in server side".to_string(),
-            };
-            write_response(conn, response)
-                .instrument_await("writing the response...")
-                .await?;
-            return Ok(());
+            }));
         }
 
         let app = app.unwrap();
@@ -156,10 +156,9 @@ impl GetMemoryDataRequestCommand {
         let result = app.select(ctx).instrument_await("selecting...").await;
         let read_elapsed = read_timer.elapsed().as_millis();
 
-        let write_timer = Instant::now();
         let mut read_length = 0;
         let rpc_version = &app.app_config_options.get_memory_data_urpc_version;
-        match rpc_version {
+        let frame = match rpc_version {
             RpcVersion::V1 => {
                 let response = match result {
                     Err(e) => GetMemoryDataResponseCommand {
@@ -178,10 +177,7 @@ impl GetMemoryDataRequestCommand {
                         }
                     }
                 };
-                let frame = Frame::GetMemoryDataResponse(response);
-                conn.write_frame(&frame)
-                    .instrument_await("writing the V1 response...")
-                    .await?;
+                Frame::GetMemoryDataResponse(response)
             }
             _ => {
                 let response = match result {
@@ -201,16 +197,12 @@ impl GetMemoryDataRequestCommand {
                         }
                     }
                 };
-                let frame = Frame::GetMemoryDataV2Response(response);
-                conn.write_frame(&frame)
-                    .instrument_await("writing the V2 response...")
-                    .await?;
+                Frame::GetMemoryDataV2Response(response)
             }
-        }
-        let write_elapsed = write_timer.elapsed().as_millis();
+        };
         let thread_label = util::current_thread_label();
         info!(
-            "[get_memory_data][{:?}] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}. read cost {}(ms) and socket_write cost {}(ms), thread_label: {}",
+            "[get_memory_data][{:?}] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}. read cost {}(ms), thread_label: {}",
             rpc_version,
             timer.elapsed().as_millis(),
             read_length,
@@ -218,10 +210,9 @@ impl GetMemoryDataRequestCommand {
             shuffle_id,
             partition_id,
             read_elapsed,
-            write_elapsed,
             thread_label,
         );
-        Ok(())
+        Ok(frame)
     }
 }
 
@@ -283,12 +274,7 @@ pub struct ReadSegment {
 }
 
 impl GetLocalDataRequestV2Command {
-    pub(crate) async fn apply(
-        &self,
-        app_manager_ref: AppManagerRef,
-        conn: &mut Connection,
-        shutdown: &mut Shutdown,
-    ) -> Result<()> {
+    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -309,11 +295,7 @@ impl GetLocalDataRequestV2Command {
                 ret_msg: "No such app in server side".to_string(),
                 data: Default::default(),
             };
-            let frame = Frame::GetLocalDataResponse(command);
-            conn.write_frame(&frame)
-                .instrument_await("No such app and then fast return")
-                .await?;
-            return Ok(());
+            return Ok(Frame::GetLocalDataResponse(command));
         }
 
         let app = app.unwrap();
@@ -357,34 +339,21 @@ impl GetLocalDataRequestV2Command {
         };
         let read_elapsed = read_timer.elapsed().as_millis();
 
-        let write_timer = Instant::now();
-        let frame = Frame::GetLocalDataResponse(command);
-        conn.write_frame(&frame)
-            .instrument_await("writing the response...")
-            .await?;
-        let write_elapsed = write_timer.elapsed().as_millis();
-
         info!(
-            "[get_local_data_v2] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}. read cost {}(ms) and socket_write cost {}(ms)",
+            "[get_local_data_v2] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}. read cost {}(ms)",
             timer.elapsed().as_millis(),
             len,
             app_id,
             shuffle_id,
             partition_id,
             read_elapsed,
-            write_elapsed,
         );
-        Ok(())
+        Ok(Frame::GetLocalDataResponse(command))
     }
 }
 
 impl GetLocalDataRequestV3Command {
-    pub(crate) async fn apply(
-        &self,
-        app_manager_ref: AppManagerRef,
-        conn: &mut Connection,
-        shutdown: &mut Shutdown,
-    ) -> Result<()> {
+    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -405,11 +374,7 @@ impl GetLocalDataRequestV3Command {
                 ret_msg: "No such app in server side".to_string(),
                 data: Default::default(),
             };
-            let frame = Frame::GetLocalDataResponse(command);
-            conn.write_frame(&frame)
-                .instrument_await("No such app and then fast return")
-                .await?;
-            return Ok(());
+            return Ok(Frame::GetLocalDataResponse(command));
         }
 
         let app = app.unwrap();
@@ -453,10 +418,6 @@ impl GetLocalDataRequestV3Command {
             }
         };
 
-        let frame = Frame::GetLocalDataResponse(command);
-        conn.write_frame(&frame)
-            .instrument_await("writing the response...")
-            .await?;
         info!(
             "[get_local_data_v3] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}",
             timer.elapsed().as_millis(),
@@ -465,17 +426,12 @@ impl GetLocalDataRequestV3Command {
             shuffle_id,
             partition_id,
         );
-        Ok(())
+        Ok(Frame::GetLocalDataResponse(command))
     }
 }
 
 impl GetLocalDataRequestCommand {
-    pub(crate) async fn apply(
-        &self,
-        app_manager_ref: AppManagerRef,
-        conn: &mut Connection,
-        shutdown: &mut Shutdown,
-    ) -> Result<()> {
+    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -494,11 +450,7 @@ impl GetLocalDataRequestCommand {
                 ret_msg: "No such app in server side".to_string(),
                 data: Default::default(),
             };
-            let frame = Frame::GetLocalDataResponse(command);
-            conn.write_frame(&frame)
-                .instrument_await("No such app and then fast return")
-                .await?;
-            return Ok(());
+            return Ok(Frame::GetLocalDataResponse(command));
         }
 
         let app = app.unwrap();
@@ -540,10 +492,6 @@ impl GetLocalDataRequestCommand {
             }
         };
 
-        let frame = Frame::GetLocalDataResponse(command);
-        conn.write_frame(&frame)
-            .instrument_await("writing the response...")
-            .await?;
         info!(
             "[get_local_data] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}",
             timer.elapsed().as_millis(),
@@ -552,7 +500,7 @@ impl GetLocalDataRequestCommand {
             shuffle_id,
             partition_id,
         );
-        Ok(())
+        Ok(Frame::GetLocalDataResponse(command))
     }
 }
 
@@ -584,12 +532,7 @@ pub struct GetLocalDataIndexRequestCommand {
 }
 
 impl GetLocalDataIndexRequestCommand {
-    pub(crate) async fn apply(
-        &self,
-        app_manager_ref: AppManagerRef,
-        conn: &mut Connection,
-        shutdown: &mut Shutdown,
-    ) -> Result<()> {
+    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -606,9 +549,7 @@ impl GetLocalDataIndexRequestCommand {
                 ret_msg: "No such app in server side".to_string(),
                 data_index: Default::default(),
             };
-            let frame = Frame::GetLocalDataIndexResponse(command);
-            conn.write_frame(&frame).await?;
-            return Ok(());
+            return Ok(Frame::GetLocalDataIndexResponse(command));
         }
 
         let app = app.unwrap();
@@ -675,9 +616,6 @@ impl GetLocalDataIndexRequestCommand {
                 Frame::GetLocalDataIndexV2Response(command)
             }
         };
-        conn.write_frame(&frame)
-            .instrument_await("writing the response...")
-            .await?;
         info!(
             "[get_local_index] duration {}(ms) with {} bytes. app_id: {}, shuffle_id: {}, partition_id: {}",
             timer.elapsed().as_millis(),
@@ -686,7 +624,7 @@ impl GetLocalDataIndexRequestCommand {
             shuffle_id,
             partition_id,
         );
-        Ok(())
+        Ok(frame)
     }
 }
 
@@ -716,6 +654,38 @@ pub struct SendDataRequestCommand {
     pub(crate) timestamp: i64,
 }
 
+impl SendDataRequestCommand {
+    pub fn new(
+        request_id: i64,
+        app_id: String,
+        shuffle_id: i32,
+        blocks: HashMap<i32, Vec<Block>>,
+        ticket_id: i64,
+        timestamp: i64,
+    ) -> Self {
+        Self {
+            request_id,
+            app_id,
+            shuffle_id,
+            blocks,
+            ticket_id,
+            timestamp,
+        }
+    }
+
+    pub fn request_id(&self) -> i64 {
+        self.request_id
+    }
+
+    pub fn data_len(&self) -> usize {
+        self.blocks
+            .values()
+            .flatten()
+            .map(|block| block.data.len())
+            .sum()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RpcResponseCommand {
     pub(crate) request_id: i64,
@@ -723,18 +693,18 @@ pub struct RpcResponseCommand {
     pub(crate) ret_msg: String,
 }
 
-async fn write_response(conn: &mut Connection, command: RpcResponseCommand) -> Result<()> {
-    let frame = Frame::RpcResponse(command);
-    conn.write_frame(&frame).await
+impl RpcResponseCommand {
+    pub fn new(request_id: i64, status_code: i32, ret_msg: String) -> Self {
+        Self {
+            request_id,
+            status_code,
+            ret_msg,
+        }
+    }
 }
 
 impl SendDataRequestCommand {
-    async fn apply(
-        self,
-        app_manager_ref: AppManagerRef,
-        conn: &mut Connection,
-        shutdown: &mut Shutdown,
-    ) -> Result<()> {
+    async fn process(self, app_manager_ref: AppManagerRef) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -748,13 +718,11 @@ impl SendDataRequestCommand {
             .observe(((util::now_timestamp_as_millis() - timestamp as u128) / 1000) as f64);
         let app = app_manager_ref.get_app(&application_id);
         if app.is_none() {
-            let response = RpcResponseCommand {
+            return Ok(Frame::RpcResponse(RpcResponseCommand {
                 request_id,
                 status_code: StatusCode::NO_REGISTER.into(),
                 ret_msg: "No such app in server side".to_string(),
-            };
-            write_response(conn, response).await?;
-            return Ok(());
+            }));
         }
 
         let app = app.unwrap();
@@ -764,13 +732,11 @@ impl SendDataRequestCommand {
             .await
         {
             Err(e) => {
-                let response = RpcResponseCommand {
+                return Ok(Frame::RpcResponse(RpcResponseCommand {
                     request_id,
                     status_code: StatusCode::INTERNAL_ERROR.into(),
                     ret_msg: "No such ticket id. Maybe it has been out of date".to_string(),
-                };
-                write_response(conn, response).await?;
-                return Ok(());
+                }));
             }
             Ok(len) => len,
         };
@@ -803,9 +769,6 @@ impl SendDataRequestCommand {
                 ret_msg: "".to_string(),
             },
         };
-        write_response(conn, response)
-            .instrument_await(format!("writing response for app:{}", &app_id))
-            .await?;
         if !insert_failure_occur {
             RPC_BATCH_DATA_BYTES_HISTOGRAM
                 .with_label_values(&[&RPC_BATCH_BYTES_OPERATION::SEND_DATA.to_string()])
@@ -818,7 +781,7 @@ impl SendDataRequestCommand {
             app_id,
             shuffle_id,
         );
-        Ok(())
+        Ok(Frame::RpcResponse(response))
     }
 
     /// Inserts all partition blocks for send_data; isolated for await-tree visibility.

--- a/riffle-server/src/urpc/mod.rs
+++ b/riffle-server/src/urpc/mod.rs
@@ -6,3 +6,6 @@ pub mod frame;
 mod metrics;
 pub mod server;
 pub mod shutdown;
+
+#[cfg(all(feature = "io-uring", target_os = "linux"))]
+pub mod uring;

--- a/riffle-server/src/urpc/uring/bridge.rs
+++ b/riffle-server/src/urpc/uring/bridge.rs
@@ -1,0 +1,106 @@
+//! Bridge between the io_uring net engine and the existing urpc command
+//! processing logic.
+//!
+//! The engine thread only parses frames; the actual command execution
+//! (memory/localfile store access) is spawned onto a tokio runtime and the
+//! response is pushed back to the engine through a [`RemoteResponder`].
+
+use crate::app_manager::AppManagerRef;
+use crate::runtime::RuntimeRef;
+use crate::store::DataBytes;
+use crate::urpc::command::Command;
+use crate::urpc::frame::Frame;
+use crate::urpc::metrics::RequestMetricTracker;
+use crate::urpc::uring::engine::{FrameHandler, Responder};
+use anyhow::Result;
+use bytes::Bytes;
+use log::error;
+
+pub struct AppCommandBridgeHandler {
+    app_manager: AppManagerRef,
+    runtime: RuntimeRef,
+}
+
+impl AppCommandBridgeHandler {
+    pub fn new(app_manager: AppManagerRef, runtime: RuntimeRef) -> Self {
+        Self {
+            app_manager,
+            runtime,
+        }
+    }
+}
+
+impl FrameHandler for AppCommandBridgeHandler {
+    fn on_frame(&mut self, frame: Frame, responder: &mut Responder<'_>) {
+        let tracker = RequestMetricTracker::new(&frame);
+        tracker.start();
+
+        let command = match Command::from_frame(frame) {
+            Ok(command) => command,
+            Err(e) => {
+                error!("Errors on decoding the urpc frame to command. {:#?}", e);
+                return;
+            }
+        };
+
+        let remote = responder.remote();
+        let app_manager = self.app_manager.clone();
+        self.runtime.spawn(async move {
+            let _tracker = tracker;
+            match command.process(app_manager).await {
+                Ok(frame) => match materialize_frame_data(frame) {
+                    Ok(frame) => {
+                        if let Err(e) = remote.respond(&frame) {
+                            error!("Errors on encoding the urpc response frame. {:#?}", e);
+                        }
+                    }
+                    Err(e) => {
+                        error!("Errors on materializing the response data. {:#?}", e);
+                    }
+                },
+                Err(e) => {
+                    error!("Errors on handling the urpc request. {:#?}", e);
+                }
+            }
+        });
+    }
+}
+
+/// The uring engine only writes in-memory payloads. Raw fd/pipe based
+/// payloads (produced by sendfile/splice read modes) are materialized into
+/// memory here.
+fn materialize_frame_data(frame: Frame) -> Result<Frame> {
+    match frame {
+        Frame::GetLocalDataResponse(mut resp) => {
+            resp.data = materialize_data_bytes(resp.data)?;
+            Ok(Frame::GetLocalDataResponse(resp))
+        }
+        Frame::GetLocalDataIndexResponse(mut resp) => {
+            resp.data_index.index_data = materialize_data_bytes(resp.data_index.index_data)?;
+            Ok(Frame::GetLocalDataIndexResponse(resp))
+        }
+        Frame::GetLocalDataIndexV2Response(mut resp) => {
+            resp.data_index.index_data = materialize_data_bytes(resp.data_index.index_data)?;
+            Ok(Frame::GetLocalDataIndexV2Response(resp))
+        }
+        other => Ok(other),
+    }
+}
+
+fn materialize_data_bytes(data: DataBytes) -> Result<DataBytes> {
+    match data {
+        DataBytes::RawIO(raw) => {
+            use std::os::unix::fs::FileExt;
+            let mut buf = vec![0u8; raw.length as usize];
+            raw.file.read_exact_at(&mut buf, raw.offset)?;
+            Ok(DataBytes::Direct(Bytes::from(buf)))
+        }
+        DataBytes::RawPipe(mut pipe) => {
+            use std::io::Read;
+            let mut buf = vec![0u8; pipe.length];
+            pipe.pipe_out_fd.read_exact(&mut buf)?;
+            Ok(DataBytes::Direct(Bytes::from(buf)))
+        }
+        other => Ok(other),
+    }
+}

--- a/riffle-server/src/urpc/uring/encode.rs
+++ b/riffle-server/src/urpc/uring/encode.rs
@@ -1,0 +1,326 @@
+//! Wire-level encode/decode helpers for the io_uring based urpc net engine.
+//!
+//! The encoded layout MUST stay byte-identical with [`Frame::write_with_mode`]
+//! (see `urpc/frame.rs`), so that clients cannot distinguish which net engine
+//! serves them.
+
+use crate::error::WorkerError;
+use crate::store::{Block, DataBytes, ResponseData};
+use crate::urpc::command::SendDataRequestCommand;
+use crate::urpc::frame::{get_i32, get_i64, get_string, get_u8, Frame, MessageType};
+use anyhow::{anyhow, Result};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::collections::HashMap;
+use std::io::Cursor;
+
+/// content_length(i32) + message_type(u8) + body_length(i32)
+pub const FRAME_HEADER_LEN: usize = 4 + 1 + 4;
+
+/// Parsed frame header of an inbound request.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestHeader {
+    pub content_len: usize,
+    pub body_len: usize,
+}
+
+impl RequestHeader {
+    pub fn total_len(&self) -> usize {
+        FRAME_HEADER_LEN + self.content_len + self.body_len
+    }
+}
+
+/// Peeks the frame header from the buffered bytes without consuming them.
+/// Returns `None` if fewer than [`FRAME_HEADER_LEN`] bytes are available.
+pub fn peek_request_header(buf: &[u8]) -> Result<Option<RequestHeader>, WorkerError> {
+    if buf.len() < FRAME_HEADER_LEN {
+        return Ok(None);
+    }
+    let mut cursor = Cursor::new(buf);
+    let content_len = get_i32(&mut cursor)?;
+    let _message_type = get_u8(&mut cursor)?;
+    let body_len = get_i32(&mut cursor)?;
+    if content_len < 0 || body_len < 0 {
+        return Err(WorkerError::STREAM_INCORRECT(format!(
+            "negative frame length. content_len: {}, body_len: {}",
+            content_len, body_len
+        )));
+    }
+    Ok(Some(RequestHeader {
+        content_len: content_len as usize,
+        body_len: body_len as usize,
+    }))
+}
+
+/// Parses one complete request frame. `frame_bytes` must contain exactly one
+/// frame (header included), as sliced out by the engine according to
+/// [`peek_request_header`].
+///
+/// For `SendShuffleData` the block payloads are zero-copy slices of
+/// `frame_bytes` instead of the copying path in [`Frame::parse`].
+pub fn parse_request_frame(frame_bytes: Bytes) -> Result<Frame, WorkerError> {
+    let mut cursor = Cursor::new(&frame_bytes[..]);
+    let _content_len = get_i32(&mut cursor)?;
+    let message_type = get_u8(&mut cursor)?;
+    let _body_len = get_i32(&mut cursor)?;
+
+    if message_type == MessageType::SendShuffleData as u8 {
+        return parse_send_shuffle_data_zero_copy(&frame_bytes, &mut cursor);
+    }
+
+    cursor.set_position(0);
+    Frame::parse(&mut cursor)
+}
+
+fn ensure_remaining(
+    cursor: &Cursor<&[u8]>,
+    len: usize,
+    field: &'static str,
+) -> Result<(), WorkerError> {
+    if cursor.remaining() < len {
+        return Err(WorkerError::STREAM_INCORRECT(format!(
+            "{field} requires {len} bytes, but only {} remaining",
+            cursor.remaining()
+        )));
+    }
+    Ok(())
+}
+
+fn read_len(cursor: &mut Cursor<&[u8]>, field: &'static str) -> Result<usize, WorkerError> {
+    let len = get_i32(cursor)?;
+    if len < 0 {
+        return Err(WorkerError::STREAM_INCORRECT(format!(
+            "{field} should not be negative: {len}"
+        )));
+    }
+    Ok(len as usize)
+}
+
+fn skip_string(cursor: &mut Cursor<&[u8]>, field: &'static str) -> Result<(), WorkerError> {
+    let len = read_len(cursor, field)?;
+    ensure_remaining(cursor, len, field)?;
+    cursor.advance(len);
+    Ok(())
+}
+
+fn parse_send_shuffle_data_zero_copy(
+    frame_bytes: &Bytes,
+    cursor: &mut Cursor<&[u8]>,
+) -> Result<Frame, WorkerError> {
+    let request_id = get_i64(cursor)?;
+    let app_id = get_string(cursor)?;
+    let shuffle_id = get_i32(cursor)?;
+    let ticket_id = get_i64(cursor)?;
+
+    let partition_batch_size = read_len(cursor, "send.partition_batch_size")?;
+    let mut blocks_map: HashMap<i32, Vec<Block>> = HashMap::with_capacity(partition_batch_size);
+    for _ in 0..partition_batch_size {
+        let partition_id = get_i32(cursor)?;
+        let block_batch_size = read_len(cursor, "send.block_batch_size")?;
+        let mut blocks = Vec::with_capacity(block_batch_size);
+        for _ in 0..block_batch_size {
+            let _pid = get_i32(cursor)?;
+            let block_id = get_i64(cursor)?;
+            let length = get_i32(cursor)?;
+            let _shuffle_id = get_i32(cursor)?;
+            let crc = get_i64(cursor)?;
+            let task_attempt_id = get_i64(cursor)?;
+
+            let data_len = get_i32(cursor)?;
+            let data = if data_len <= 0 {
+                Bytes::new()
+            } else {
+                let data_len = data_len as usize;
+                ensure_remaining(cursor, data_len, "send.block.data")?;
+                let pos = cursor.position() as usize;
+                // Zero-copy: the block payload shares the receive buffer allocation.
+                let data = frame_bytes.slice(pos..pos + data_len);
+                cursor.advance(data_len);
+                data
+            };
+
+            let shuffle_server_len = read_len(cursor, "send.block.shuffle_server_len")?;
+            for _ in 0..shuffle_server_len {
+                skip_string(cursor, "send.block.shuffle_server.id")?;
+                skip_string(cursor, "send.block.shuffle_server.host")?;
+                ensure_remaining(cursor, 8, "send.block.shuffle_server.ports")?;
+                cursor.advance(8);
+            }
+
+            let uncompress_length = get_i32(cursor)?;
+            let _free_mem = get_i64(cursor)?;
+
+            blocks.push(Block {
+                block_id,
+                length,
+                uncompress_length,
+                crc,
+                data,
+                task_attempt_id,
+            });
+        }
+        blocks_map.insert(partition_id, blocks);
+    }
+    let timestamp = get_i64(cursor)?;
+
+    Ok(Frame::SendShuffleData(SendDataRequestCommand::new(
+        request_id, app_id, shuffle_id, blocks_map, ticket_id, timestamp,
+    )))
+}
+
+/// Appends the data payload of a response as separate zero-copy chunks.
+fn push_data_chunks(data: &DataBytes, chunks: &mut Vec<Bytes>) -> Result<()> {
+    match data {
+        DataBytes::Direct(bytes) => {
+            if !bytes.is_empty() {
+                chunks.push(bytes.clone());
+            }
+        }
+        DataBytes::Composed(composed) => {
+            for chunk in composed.iter() {
+                if !chunk.is_empty() {
+                    chunks.push(chunk.clone());
+                }
+            }
+        }
+        DataBytes::RawIO(_) | DataBytes::RawPipe(_) => {
+            return Err(anyhow!(
+                "The io_uring net engine requires in-memory response data, \
+                 but got a raw fd/pipe based payload. Materialize it first."
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Encodes a response frame: the fixed meta part is appended into `head`,
+/// while large data payloads are pushed into `chunks` (in wire order, to be
+/// written right after `head`). The byte layout replicates
+/// [`Frame::write_with_mode`].
+pub fn encode_frame_into(
+    frame: &Frame,
+    head: &mut BytesMut,
+    chunks: &mut Vec<Bytes>,
+) -> Result<()> {
+    match frame {
+        Frame::RpcResponse(resp) => {
+            let msg_bytes = resp.ret_msg.as_bytes();
+            head.reserve(FRAME_HEADER_LEN + 16 + msg_bytes.len());
+            head.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4);
+            head.put_u8(MessageType::RpcResponse as u8);
+            head.put_i32(0);
+            head.put_i64(resp.request_id);
+            head.put_i32(resp.status_code);
+            head.put_i32(msg_bytes.len() as i32);
+            head.put(msg_bytes);
+        }
+        Frame::GetLocalDataResponse(resp) => {
+            let msg_bytes = resp.ret_msg.as_bytes();
+            let data = &resp.data;
+            head.reserve(FRAME_HEADER_LEN + 16 + msg_bytes.len());
+            head.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4);
+            head.put_u8(MessageType::GetLocalDataResponse as u8);
+            head.put_i32(data.len() as i32);
+            head.put_i64(resp.request_id);
+            head.put_i32(resp.status_code);
+            head.put_i32(msg_bytes.len() as i32);
+            head.put(msg_bytes);
+            push_data_chunks(data, chunks)?;
+        }
+        Frame::GetLocalDataIndexResponse(resp) => {
+            let msg_bytes = resp.ret_msg.as_bytes();
+            let index_bytes = &resp.data_index.index_data;
+            head.reserve(FRAME_HEADER_LEN + 24 + msg_bytes.len());
+            head.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + 8);
+            head.put_u8(MessageType::GetLocalDataIndexResponse as u8);
+            head.put_i32(index_bytes.len() as i32);
+            head.put_i64(resp.request_id);
+            head.put_i32(resp.status_code);
+            head.put_i32(msg_bytes.len() as i32);
+            head.put(msg_bytes);
+            head.put_i64(resp.data_index.data_file_len);
+            push_data_chunks(index_bytes, chunks)?;
+        }
+        Frame::GetLocalDataIndexV2Response(resp) => {
+            let msg_bytes = resp.ret_msg.as_bytes();
+            let index_bytes = &resp.data_index.index_data;
+            head.reserve(FRAME_HEADER_LEN + 28 + msg_bytes.len() + 4 * resp.storage_ids.len());
+            head.put_i32(
+                msg_bytes.len() as i32 + 8 + 4 + 4 + 8 + 4 + 4 * resp.storage_ids.len() as i32,
+            );
+            head.put_u8(MessageType::GetLocalDataIndexV2Response as u8);
+            head.put_i32(index_bytes.len() as i32);
+            head.put_i64(resp.request_id);
+            head.put_i32(resp.status_code);
+            head.put_i32(msg_bytes.len() as i32);
+            head.put(msg_bytes);
+            head.put_i64(resp.data_index.data_file_len);
+            head.put_i32(resp.storage_ids.len() as i32);
+            for storage_id in &resp.storage_ids {
+                head.put_i32(*storage_id as i32);
+            }
+            push_data_chunks(index_bytes, chunks)?;
+        }
+        Frame::GetMemoryDataResponse(resp) => {
+            let mem_data = match &resp.data {
+                ResponseData::Mem(mem_data) => mem_data,
+                _ => return Err(anyhow!("GetMemoryDataResponse requires mem typed data")),
+            };
+            let msg_bytes = resp.ret_msg.as_bytes();
+            let segments = &mem_data.shuffle_data_block_segments;
+            let segments_encode_len = (4 + segments.len() * (3 * 8 + 3 * 4)) as i32;
+            head.reserve(FRAME_HEADER_LEN + 16 + msg_bytes.len() + segments_encode_len as usize);
+            head.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + segments_encode_len);
+            head.put_u8(MessageType::GetMemoryDataResponse as u8);
+            head.put_i32(mem_data.data.len() as i32);
+            head.put_i64(resp.request_id);
+            head.put_i32(resp.status_code);
+            head.put_i32(msg_bytes.len() as i32);
+            head.put(msg_bytes);
+            head.put_i32(segments.len() as i32);
+            for segment in segments {
+                head.put_i64(segment.block_id);
+                head.put_i32(segment.offset as i32);
+                head.put_i32(segment.length);
+                head.put_i32(segment.uncompress_length);
+                head.put_i64(segment.crc);
+                head.put_i64(segment.task_attempt_id);
+            }
+            push_data_chunks(&mem_data.data, chunks)?;
+        }
+        Frame::GetMemoryDataV2Response(resp) => {
+            let mem_data = match &resp.data {
+                ResponseData::Mem(mem_data) => mem_data,
+                _ => return Err(anyhow!("GetMemoryDataV2Response requires mem typed data")),
+            };
+            let msg_bytes = resp.ret_msg.as_bytes();
+            let segments = &mem_data.shuffle_data_block_segments;
+            let segments_encode_len = (4 + segments.len() * (3 * 8 + 3 * 4)) as i32;
+            head.reserve(FRAME_HEADER_LEN + 17 + msg_bytes.len() + segments_encode_len as usize);
+            head.put_i32(msg_bytes.len() as i32 + 8 + 4 + 4 + segments_encode_len + 1);
+            head.put_u8(MessageType::GetMemoryDataV2Response as u8);
+            head.put_i32(mem_data.data.len() as i32);
+            head.put_i64(resp.request_id);
+            head.put_i32(resp.status_code);
+            head.put_i32(msg_bytes.len() as i32);
+            head.put(msg_bytes);
+            head.put_i32(segments.len() as i32);
+            for segment in segments {
+                head.put_i64(segment.block_id);
+                head.put_i32(segment.offset as i32);
+                head.put_i32(segment.length);
+                head.put_i32(segment.uncompress_length);
+                head.put_i64(segment.crc);
+                head.put_i64(segment.task_attempt_id);
+            }
+            head.put_u8(mem_data.is_end as u8);
+            push_data_chunks(&mem_data.data, chunks)?;
+        }
+        other => {
+            return Err(anyhow!(
+                "The io_uring net engine cannot encode frame type: {}",
+                other
+            ));
+        }
+    }
+    Ok(())
+}

--- a/riffle-server/src/urpc/uring/engine.rs
+++ b/riffle-server/src/urpc/uring/engine.rs
@@ -60,7 +60,7 @@ pub struct UringServerConfig {
     /// Enable kernel side SQ polling with the given idle time in ms.
     /// Requires CAP_SYS_ADMIN on kernels older than 5.13.
     pub sqpoll_idle_ms: Option<u32>,
-    /// Minimum spare capacity armed for every recv.
+    /// Minimum receive size while the next frame length is unknown.
     pub recv_chunk_size: usize,
     /// Initial per-connection read buffer capacity.
     pub initial_read_buffer_size: usize,
@@ -204,7 +204,7 @@ struct Conn {
     recv_inflight: bool,
     send_inflight: bool,
     closing: bool,
-    /// Total length of the partially received frame, used to size reads.
+    /// Total length of the partially received frame.
     pending_frame_len: Option<usize>,
 }
 
@@ -329,37 +329,51 @@ impl<H: FrameHandler> UringEngine<H> {
     }
 
     fn arm_recv(&mut self, slot: u32) {
-        let (fd, token, ptr, len) = {
+        let (fd, token, ptr, len, recv_flags) = {
             let Some(conn) = self.conns[slot as usize].as_mut() else {
                 return;
             };
             if conn.recv_inflight || conn.closing {
                 return;
             }
-            // When a large frame is being accumulated, reserve enough room to
-            // receive the rest of it in as few operations as possible.
-            let spare_wanted = match conn.pending_frame_len {
-                Some(total) if total > conn.read_buf.len() => {
-                    (total - conn.read_buf.len()).max(self.cfg.recv_chunk_size)
-                }
-                _ => self.cfg.recv_chunk_size,
-            };
+
+            let frame_remaining = conn
+                .pending_frame_len
+                .and_then(|total| total.checked_sub(conn.read_buf.len()))
+                .filter(|remaining| *remaining > 0);
+            debug_assert_eq!(
+                conn.pending_frame_len.is_some(),
+                frame_remaining.is_some(),
+                "pending frame must be incomplete before arming recv"
+            );
+
+            let spare_wanted = frame_remaining.unwrap_or(self.cfg.recv_chunk_size);
             let spare = conn.read_buf.capacity() - conn.read_buf.len();
             if spare < spare_wanted {
                 conn.read_buf.reserve(spare_wanted);
             }
             let offset = conn.read_buf.len();
             let spare = conn.read_buf.capacity() - offset;
+            let (recv_len, recv_flags) = match frame_remaining {
+                // Waiting for the exact remainder completes a large frame in
+                // one CQE without consuming the next pipelined frame.
+                Some(remaining) => (remaining, libc::MSG_WAITALL),
+                None => (spare, 0),
+            };
             let ptr = unsafe { conn.read_buf.as_mut_ptr().add(offset) };
             conn.recv_inflight = true;
             (
                 conn.fd,
                 pack_token(KIND_RECV, conn.gen, slot),
                 ptr,
-                spare as u32,
+                u32::try_from(recv_len).unwrap_or(u32::MAX),
+                recv_flags,
             )
         };
-        let sqe = opcode::Recv::new(Fd(fd), ptr, len).build().user_data(token);
+        let sqe = opcode::Recv::new(Fd(fd), ptr, len)
+            .flags(recv_flags)
+            .build()
+            .user_data(token);
         self.push_sqe(sqe);
     }
 
@@ -807,6 +821,12 @@ mod tests {
         Ok((request_id, status_code, msg))
     }
 
+    async fn read_rpc_response_with_timeout(
+        stream: &mut TcpStream,
+    ) -> anyhow::Result<(i64, i32, String)> {
+        Ok(tokio::time::timeout(Duration::from_secs(5), read_rpc_response(stream)).await??)
+    }
+
     fn echo_handler(frame: Frame, responder: &mut Responder<'_>) {
         match frame {
             Frame::SendShuffleData(req) => {
@@ -881,6 +901,79 @@ mod tests {
         }
 
         drop(stream);
+        server.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn echo_fragmented_large_frame_preserves_pipelined_frame() -> anyhow::Result<()> {
+        let server = start_echo_server();
+        let mut stream = TcpStream::connect(server.local_addr()).await?;
+
+        let large_payload = vec![5u8; 2 * 1024 * 1024];
+        let large_frame = build_send_shuffle_data_frame(1, &large_payload);
+        let small_payload = vec![6u8; 128];
+        let small_frame = build_send_shuffle_data_frame(2, &small_payload);
+
+        let first_chunk_len = 64 * 1024;
+        stream.write_all(&large_frame[..first_chunk_len]).await?;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let mut remainder_and_next =
+            BytesMut::with_capacity(large_frame.len() - first_chunk_len + small_frame.len());
+        remainder_and_next.extend_from_slice(&large_frame[first_chunk_len..]);
+        remainder_and_next.extend_from_slice(&small_frame);
+        stream.write_all(&remainder_and_next).await?;
+
+        let (request_id, status, msg) = read_rpc_response_with_timeout(&mut stream).await?;
+        assert_eq!(1, request_id);
+        assert_eq!(0, status);
+        assert_eq!(format!("len={}", large_payload.len()), msg);
+
+        let (request_id, status, msg) = read_rpc_response_with_timeout(&mut stream).await?;
+        assert_eq!(2, request_id);
+        assert_eq!(0, status);
+        assert_eq!(format!("len={}", small_payload.len()), msg);
+
+        drop(stream);
+        server.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fragmented_large_frame_does_not_block_another_connection() -> anyhow::Result<()> {
+        let server = start_echo_server();
+        let mut slow_stream = TcpStream::connect(server.local_addr()).await?;
+
+        let slow_payload = vec![7u8; 2 * 1024 * 1024];
+        let slow_frame = build_send_shuffle_data_frame(1, &slow_payload);
+        let first_chunk_len = 64 * 1024;
+        slow_stream
+            .write_all(&slow_frame[..first_chunk_len])
+            .await?;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let mut fast_stream = TcpStream::connect(server.local_addr()).await?;
+        fast_stream
+            .write_all(&build_send_shuffle_data_frame(2, &[8u8; 128]))
+            .await?;
+        let (request_id, status, msg) =
+            tokio::time::timeout(Duration::from_secs(1), read_rpc_response(&mut fast_stream))
+                .await??;
+        assert_eq!(2, request_id);
+        assert_eq!(0, status);
+        assert_eq!("len=128", msg);
+
+        slow_stream
+            .write_all(&slow_frame[first_chunk_len..])
+            .await?;
+        let (request_id, status, msg) = read_rpc_response_with_timeout(&mut slow_stream).await?;
+        assert_eq!(1, request_id);
+        assert_eq!(0, status);
+        assert_eq!(format!("len={}", slow_payload.len()), msg);
+
+        drop(fast_stream);
+        drop(slow_stream);
         server.shutdown();
         Ok(())
     }

--- a/riffle-server/src/urpc/uring/engine.rs
+++ b/riffle-server/src/urpc/uring/engine.rs
@@ -1,0 +1,923 @@
+//! A self-contained, completion-driven io_uring network engine for urpc.
+//!
+//! Design goals:
+//! - No dependency on any async runtime in the hot loop: one OS thread drives
+//!   one `io_uring` instance with a per-connection state machine.
+//! - Kernel 5.10 baseline: plain (re-armed) accept/recv/send, batched
+//!   submissions via a single `io_uring_enter` per loop iteration, relying on
+//!   `IORING_FEAT_FAST_POLL` for readiness handling.
+//! - Pluggable request handling: the engine only understands urpc frames.
+//!   A [`FrameHandler`] decides how to answer, either inline (on the engine
+//!   thread) or asynchronously from any other thread via [`RemoteResponder`]
+//!   (eventfd based wakeup).
+//!
+//! Known limitations (documented, intentional for now):
+//! - Response payloads must be in-memory bytes (`DataBytes::Direct/Composed`).
+//!   Raw fd/pipe payloads must be materialized by the handler beforehand.
+//! - The per-connection outbound queue is unbounded; with request/response
+//!   style traffic it is effectively bounded by the client pipeline depth.
+
+use crate::urpc::frame::Frame;
+use crate::urpc::uring::encode::{encode_frame_into, parse_request_frame, peek_request_header};
+use anyhow::{anyhow, Context, Result};
+use bytes::{Bytes, BytesMut};
+use crossbeam::queue::SegQueue;
+use io_uring::types::Fd;
+use io_uring::{opcode, squeue, IoUring};
+use log::{debug, error, info, warn};
+use std::collections::VecDeque;
+use std::net::{SocketAddr, TcpListener};
+use std::os::fd::{AsRawFd, RawFd};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+const KIND_REMOTE: u64 = 0;
+const KIND_ACCEPT: u64 = 1;
+const KIND_RECV: u64 = 2;
+const KIND_SEND: u64 = 3;
+const KIND_WAKE: u64 = 4;
+
+#[inline]
+fn pack_token(kind: u64, gen: u16, slot: u32) -> u64 {
+    (kind << 56) | ((gen as u64) << 32) | (slot as u64)
+}
+
+#[inline]
+fn unpack_token(token: u64) -> (u64, u16, u32) {
+    (
+        token >> 56,
+        ((token >> 32) & 0xffff) as u16,
+        (token & 0xffff_ffff) as u32,
+    )
+}
+
+/// Tuning knobs of the engine. Defaults are sized for a shuffle workload.
+#[derive(Debug, Clone)]
+pub struct UringServerConfig {
+    /// io_uring submission queue depth.
+    pub ring_entries: u32,
+    /// Enable kernel side SQ polling with the given idle time in ms.
+    /// Requires CAP_SYS_ADMIN on kernels older than 5.13.
+    pub sqpoll_idle_ms: Option<u32>,
+    /// Minimum spare capacity armed for every recv.
+    pub recv_chunk_size: usize,
+    /// Initial per-connection read buffer capacity.
+    pub initial_read_buffer_size: usize,
+    /// Read buffers larger than this are shrunk once drained.
+    pub read_buffer_shrink_threshold: usize,
+    /// Hard cap of concurrent connections per engine thread.
+    pub max_connections: usize,
+    /// Optional cpu binding: engine thread `i` is pinned to
+    /// `bind_cores[i % len]`.
+    pub bind_cores: Option<Vec<u32>>,
+}
+
+impl Default for UringServerConfig {
+    fn default() -> Self {
+        Self {
+            ring_entries: 1024,
+            sqpoll_idle_ms: None,
+            recv_chunk_size: 64 * 1024,
+            initial_read_buffer_size: 32 * 1024,
+            read_buffer_shrink_threshold: 1024 * 1024,
+            max_connections: 65536,
+            bind_cores: None,
+        }
+    }
+}
+
+/// Pluggable request handling hook.
+///
+/// `on_frame` is invoked on the engine thread for every complete request
+/// frame. Cheap handlers should answer inline through
+/// [`Responder::respond`]; expensive/async handlers should capture a
+/// [`RemoteResponder`] (via [`Responder::remote`]) and complete the request
+/// from another thread.
+pub trait FrameHandler: Send + 'static {
+    fn on_frame(&mut self, frame: Frame, responder: &mut Responder<'_>);
+}
+
+impl<F> FrameHandler for F
+where
+    F: FnMut(Frame, &mut Responder<'_>) + Send + 'static,
+{
+    fn on_frame(&mut self, frame: Frame, responder: &mut Responder<'_>) {
+        self(frame, responder)
+    }
+}
+
+pub(crate) struct EngineShared {
+    remote_queue: SegQueue<(u64, Vec<Bytes>)>,
+    wake_fd: RawFd,
+    stopped: AtomicBool,
+}
+
+impl EngineShared {
+    fn wake(&self) {
+        let one: u64 = 1;
+        let ret = unsafe {
+            libc::write(
+                self.wake_fd,
+                &one as *const u64 as *const libc::c_void,
+                std::mem::size_of::<u64>(),
+            )
+        };
+        if ret < 0 {
+            error!(
+                "Failed to wake the uring engine eventfd: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+}
+
+impl Drop for EngineShared {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.wake_fd);
+        }
+    }
+}
+
+/// Inline responder handed to [`FrameHandler::on_frame`].
+pub struct Responder<'a> {
+    conn: &'a mut Conn,
+    token: u64,
+    shared: &'a Arc<EngineShared>,
+}
+
+impl Responder<'_> {
+    /// Encodes the response into the connection outbound queue. Multiple
+    /// small responses within one receive batch are coalesced into a single
+    /// send operation.
+    pub fn respond(&mut self, frame: &Frame) -> Result<()> {
+        let mut chunks = Vec::new();
+        encode_frame_into(frame, &mut self.conn.out_head, &mut chunks)?;
+        for chunk in chunks {
+            self.conn.flush_head_to_queue();
+            self.conn.out_queue.push_back(chunk);
+        }
+        Ok(())
+    }
+
+    /// Creates a thread-safe handle for completing this request later.
+    pub fn remote(&self) -> RemoteResponder {
+        RemoteResponder {
+            token: self.token,
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+/// Thread-safe response handle. Responses posted after the connection has
+/// been closed are silently dropped.
+#[derive(Clone)]
+pub struct RemoteResponder {
+    token: u64,
+    shared: Arc<EngineShared>,
+}
+
+impl RemoteResponder {
+    pub fn respond(&self, frame: &Frame) -> Result<()> {
+        let mut head = BytesMut::with_capacity(256);
+        let mut chunks = Vec::new();
+        encode_frame_into(frame, &mut head, &mut chunks)?;
+        let mut bufs = Vec::with_capacity(1 + chunks.len());
+        bufs.push(head.freeze());
+        bufs.extend(chunks);
+        self.shared.remote_queue.push((self.token, bufs));
+        self.shared.wake();
+        Ok(())
+    }
+}
+
+struct Conn {
+    fd: RawFd,
+    gen: u16,
+    read_buf: BytesMut,
+    /// Staging buffer coalescing the meta parts of pending responses.
+    out_head: BytesMut,
+    out_queue: VecDeque<Bytes>,
+    /// Bytes of the queue front that are already sent.
+    out_offset: usize,
+    recv_inflight: bool,
+    send_inflight: bool,
+    closing: bool,
+    /// Total length of the partially received frame, used to size reads.
+    pending_frame_len: Option<usize>,
+}
+
+impl Conn {
+    fn new(fd: RawFd, gen: u16, initial_read_buffer_size: usize) -> Self {
+        Self {
+            fd,
+            gen,
+            read_buf: BytesMut::with_capacity(initial_read_buffer_size),
+            out_head: BytesMut::new(),
+            out_queue: VecDeque::new(),
+            out_offset: 0,
+            recv_inflight: false,
+            send_inflight: false,
+            closing: false,
+            pending_frame_len: None,
+        }
+    }
+
+    fn flush_head_to_queue(&mut self) {
+        if !self.out_head.is_empty() {
+            let head = self.out_head.split().freeze();
+            self.out_queue.push_back(head);
+        }
+    }
+
+    fn has_inflight(&self) -> bool {
+        self.recv_inflight || self.send_inflight
+    }
+}
+
+struct UringEngine<H: FrameHandler> {
+    ring: IoUring,
+    listener: TcpListener,
+    cfg: UringServerConfig,
+    conns: Vec<Option<Conn>>,
+    /// Per-slot generation, bumped on every close to fence stale tokens.
+    slot_gens: Vec<u16>,
+    free_slots: Vec<u32>,
+    handler: H,
+    shared: Arc<EngineShared>,
+    /// Target buffer of the eventfd read op; boxed for address stability.
+    wake_buf: Box<u64>,
+    accept_inflight: bool,
+}
+
+impl<H: FrameHandler> UringEngine<H> {
+    fn new(listener: TcpListener, cfg: UringServerConfig, handler: H) -> Result<Self> {
+        let mut builder = IoUring::builder();
+        if let Some(idle) = cfg.sqpoll_idle_ms {
+            builder.setup_sqpoll(idle);
+        }
+        let ring = builder
+            .build(cfg.ring_entries)
+            .context("failed to build io_uring instance")?;
+
+        let wake_fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC) };
+        if wake_fd < 0 {
+            return Err(anyhow!(
+                "failed to create eventfd: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        Ok(Self {
+            ring,
+            listener,
+            cfg,
+            conns: Vec::new(),
+            slot_gens: Vec::new(),
+            free_slots: Vec::new(),
+            handler,
+            shared: Arc::new(EngineShared {
+                remote_queue: SegQueue::new(),
+                wake_fd,
+                stopped: AtomicBool::new(false),
+            }),
+            wake_buf: Box::new(0),
+            accept_inflight: false,
+        })
+    }
+
+    fn shared(&self) -> Arc<EngineShared> {
+        self.shared.clone()
+    }
+
+    fn push_sqe(&mut self, sqe: squeue::Entry) {
+        loop {
+            let pushed = unsafe { self.ring.submission().push(&sqe) };
+            if pushed.is_ok() {
+                return;
+            }
+            // SQ full: flush what we have and retry.
+            if let Err(e) = self.ring.submit() {
+                error!("io_uring submit on full SQ failed: {}", e);
+            }
+        }
+    }
+
+    fn arm_wake(&mut self) {
+        let ptr = &mut *self.wake_buf as *mut u64 as *mut u8;
+        let sqe = opcode::Read::new(Fd(self.shared.wake_fd), ptr, 8)
+            .build()
+            .user_data(pack_token(KIND_WAKE, 0, 0));
+        self.push_sqe(sqe);
+    }
+
+    fn arm_accept(&mut self) {
+        if self.accept_inflight {
+            return;
+        }
+        self.accept_inflight = true;
+        let sqe = opcode::Accept::new(
+            Fd(self.listener.as_raw_fd()),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+        .flags(libc::SOCK_CLOEXEC)
+        .build()
+        .user_data(pack_token(KIND_ACCEPT, 0, 0));
+        self.push_sqe(sqe);
+    }
+
+    fn arm_recv(&mut self, slot: u32) {
+        let (fd, token, ptr, len) = {
+            let Some(conn) = self.conns[slot as usize].as_mut() else {
+                return;
+            };
+            if conn.recv_inflight || conn.closing {
+                return;
+            }
+            // When a large frame is being accumulated, reserve enough room to
+            // receive the rest of it in as few operations as possible.
+            let spare_wanted = match conn.pending_frame_len {
+                Some(total) if total > conn.read_buf.len() => {
+                    (total - conn.read_buf.len()).max(self.cfg.recv_chunk_size)
+                }
+                _ => self.cfg.recv_chunk_size,
+            };
+            let spare = conn.read_buf.capacity() - conn.read_buf.len();
+            if spare < spare_wanted {
+                conn.read_buf.reserve(spare_wanted);
+            }
+            let offset = conn.read_buf.len();
+            let spare = conn.read_buf.capacity() - offset;
+            let ptr = unsafe { conn.read_buf.as_mut_ptr().add(offset) };
+            conn.recv_inflight = true;
+            (
+                conn.fd,
+                pack_token(KIND_RECV, conn.gen, slot),
+                ptr,
+                spare as u32,
+            )
+        };
+        let sqe = opcode::Recv::new(Fd(fd), ptr, len).build().user_data(token);
+        self.push_sqe(sqe);
+    }
+
+    fn arm_send(&mut self, slot: u32) {
+        let (fd, token, ptr, len) = {
+            let Some(conn) = self.conns[slot as usize].as_mut() else {
+                return;
+            };
+            if conn.send_inflight {
+                return;
+            }
+            conn.flush_head_to_queue();
+            let Some(front) = conn.out_queue.front() else {
+                return;
+            };
+            let ptr = unsafe { front.as_ptr().add(conn.out_offset) };
+            let len = front.len() - conn.out_offset;
+            conn.send_inflight = true;
+            (
+                conn.fd,
+                pack_token(KIND_SEND, conn.gen, slot),
+                ptr,
+                len as u32,
+            )
+        };
+        let sqe = opcode::Send::new(Fd(fd), ptr, len)
+            .flags(libc::MSG_NOSIGNAL)
+            .build()
+            .user_data(token);
+        self.push_sqe(sqe);
+    }
+
+    fn conn_mut(&mut self, slot: u32, gen: u16) -> Option<&mut Conn> {
+        match self.conns.get_mut(slot as usize).and_then(Option::as_mut) {
+            Some(conn) if conn.gen == gen => Some(conn),
+            _ => None,
+        }
+    }
+
+    fn on_accept(&mut self, res: i32) {
+        self.accept_inflight = false;
+        if !self.shared.stopped.load(Ordering::Acquire) {
+            self.arm_accept();
+        }
+        if res < 0 {
+            let errno = -res;
+            // Transient accept errors are expected under churn.
+            if errno != libc::EAGAIN && errno != libc::EINTR && errno != libc::ECONNABORTED {
+                warn!("uring accept failed with errno: {}", errno);
+            }
+            return;
+        }
+        let fd = res as RawFd;
+        let active = self.conns.iter().filter(|c| c.is_some()).count();
+        if active >= self.cfg.max_connections {
+            warn!("uring engine connection limit reached, rejecting fd {}", fd);
+            unsafe { libc::close(fd) };
+            return;
+        }
+
+        unsafe {
+            let one: libc::c_int = 1;
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_TCP,
+                libc::TCP_NODELAY,
+                &one as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                &one as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+        }
+
+        let slot = match self.free_slots.pop() {
+            Some(slot) => slot,
+            None => {
+                self.conns.push(None);
+                self.slot_gens.push(0);
+                (self.conns.len() - 1) as u32
+            }
+        };
+        let gen = self.slot_gens[slot as usize];
+        self.conns[slot as usize] = Some(Conn::new(fd, gen, self.cfg.initial_read_buffer_size));
+        self.arm_recv(slot);
+    }
+
+    fn on_recv(&mut self, slot: u32, gen: u16, res: i32) {
+        let Some(conn) = self.conn_mut(slot, gen) else {
+            return;
+        };
+        conn.recv_inflight = false;
+        if conn.closing {
+            self.maybe_finish_close(slot);
+            return;
+        }
+        if res == 0 {
+            // Clean EOF from the peer.
+            self.begin_close(slot);
+            return;
+        }
+        if res < 0 {
+            let errno = -res;
+            if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK || errno == libc::EINTR {
+                self.arm_recv(slot);
+                return;
+            }
+            debug!("uring recv failed with errno {}, closing connection", errno);
+            self.begin_close(slot);
+            return;
+        }
+
+        {
+            let conn = self.conns[slot as usize].as_mut().unwrap();
+            let filled = conn.read_buf.len() + res as usize;
+            debug_assert!(filled <= conn.read_buf.capacity());
+            unsafe { conn.read_buf.set_len(filled) };
+        }
+
+        if let Err(e) = self.process_frames(slot) {
+            warn!("Errors on handling the urpc frames, closing. err: {:#?}", e);
+            self.begin_close(slot);
+            return;
+        }
+        self.arm_send(slot);
+        self.arm_recv(slot);
+    }
+
+    fn process_frames(&mut self, slot: u32) -> Result<()> {
+        let this = &mut *self;
+        let handler = &mut this.handler;
+        let shared = &this.shared;
+        let cfg = &this.cfg;
+        let Some(conn) = this.conns[slot as usize].as_mut() else {
+            return Ok(());
+        };
+
+        loop {
+            let Some(header) = peek_request_header(&conn.read_buf)? else {
+                conn.pending_frame_len = None;
+                break;
+            };
+            let total = header.total_len();
+            if conn.read_buf.len() < total {
+                conn.pending_frame_len = Some(total);
+                break;
+            }
+            conn.pending_frame_len = None;
+
+            let frame_bytes = conn.read_buf.split_to(total).freeze();
+            let frame = parse_request_frame(frame_bytes)?;
+
+            let mut responder = Responder {
+                token: pack_token(KIND_REMOTE, conn.gen, slot),
+                conn: &mut *conn,
+                shared,
+            };
+            handler.on_frame(frame, &mut responder);
+        }
+
+        if conn.read_buf.is_empty() && conn.read_buf.capacity() > cfg.read_buffer_shrink_threshold {
+            conn.read_buf = BytesMut::with_capacity(cfg.initial_read_buffer_size);
+        }
+        Ok(())
+    }
+
+    fn on_send(&mut self, slot: u32, gen: u16, res: i32) {
+        let Some(conn) = self.conn_mut(slot, gen) else {
+            return;
+        };
+        conn.send_inflight = false;
+        if res < 0 {
+            let errno = -res;
+            if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK || errno == libc::EINTR {
+                if conn.closing {
+                    self.maybe_finish_close(slot);
+                } else {
+                    self.arm_send(slot);
+                }
+                return;
+            }
+            debug!("uring send failed with errno {}, closing connection", errno);
+            self.begin_close(slot);
+            return;
+        }
+
+        conn.out_offset += res as usize;
+        if let Some(front) = conn.out_queue.front() {
+            if conn.out_offset >= front.len() {
+                debug_assert_eq!(conn.out_offset, front.len());
+                conn.out_queue.pop_front();
+                conn.out_offset = 0;
+            }
+        }
+
+        if conn.closing {
+            self.maybe_finish_close(slot);
+        } else {
+            self.arm_send(slot);
+        }
+    }
+
+    fn drain_remote_responses(&mut self) {
+        while let Some((token, bufs)) = self.shared.remote_queue.pop() {
+            let (_, gen, slot) = unpack_token(token);
+            let Some(conn) = self.conn_mut(slot, gen) else {
+                continue;
+            };
+            if conn.closing {
+                continue;
+            }
+            // Preserve ordering with any inline-encoded pending head bytes.
+            conn.flush_head_to_queue();
+            conn.out_queue.extend(bufs);
+            self.arm_send(slot);
+        }
+    }
+
+    fn begin_close(&mut self, slot: u32) {
+        let Some(conn) = self.conns[slot as usize].as_mut() else {
+            return;
+        };
+        conn.closing = true;
+        self.maybe_finish_close(slot);
+    }
+
+    fn maybe_finish_close(&mut self, slot: u32) {
+        let should_close = match self.conns[slot as usize].as_ref() {
+            Some(conn) => conn.closing && !conn.has_inflight(),
+            None => false,
+        };
+        if !should_close {
+            return;
+        }
+        let conn = self.conns[slot as usize].take().unwrap();
+        unsafe { libc::close(conn.fd) };
+        self.slot_gens[slot as usize] = self.slot_gens[slot as usize].wrapping_add(1);
+        self.free_slots.push(slot);
+    }
+
+    fn handle_completion(&mut self, token: u64, res: i32) {
+        let (kind, gen, slot) = unpack_token(token);
+        match kind {
+            KIND_ACCEPT => self.on_accept(res),
+            KIND_RECV => self.on_recv(slot, gen, res),
+            KIND_SEND => self.on_send(slot, gen, res),
+            KIND_WAKE => {
+                self.arm_wake();
+                self.drain_remote_responses();
+            }
+            _ => warn!("unknown uring completion token kind: {}", kind),
+        }
+    }
+
+    fn run(mut self) -> Result<()> {
+        info!(
+            "uring urpc engine started on {:?}, sqpoll: {:?}",
+            self.listener.local_addr(),
+            self.cfg.sqpoll_idle_ms
+        );
+        self.arm_wake();
+        self.arm_accept();
+
+        let mut completions: Vec<(u64, i32)> = Vec::with_capacity(1024);
+        while !self.shared.stopped.load(Ordering::Acquire) {
+            self.drain_remote_responses();
+            self.ring
+                .submit_and_wait(1)
+                .context("io_uring submit_and_wait failed")?;
+            completions.clear();
+            {
+                let cq = self.ring.completion();
+                for cqe in cq {
+                    completions.push((cqe.user_data(), cqe.result()));
+                }
+            }
+            for &(token, res) in completions.iter() {
+                self.handle_completion(token, res);
+            }
+        }
+
+        // Shutdown: dropping the ring cancels all inflight operations.
+        for conn in self.conns.iter().flatten() {
+            unsafe { libc::close(conn.fd) };
+        }
+        info!("uring urpc engine stopped");
+        Ok(())
+    }
+}
+
+/// Handle of a running multi-threaded uring urpc server.
+pub struct UringUrpcServer {
+    shareds: Vec<Arc<EngineShared>>,
+    joins: Vec<JoinHandle<()>>,
+    local_addr: SocketAddr,
+}
+
+impl UringUrpcServer {
+    /// Starts `threads` engine threads, each with its own `SO_REUSEPORT`
+    /// listener and io_uring instance. `handler_factory(i)` builds the
+    /// per-thread handler.
+    pub fn start<H, F>(
+        addr: SocketAddr,
+        threads: usize,
+        cfg: UringServerConfig,
+        mut handler_factory: F,
+    ) -> Result<Self>
+    where
+        H: FrameHandler,
+        F: FnMut(usize) -> H,
+    {
+        if threads == 0 {
+            return Err(anyhow!("uring engine thread number must be greater than 0"));
+        }
+
+        let mut listeners = Vec::with_capacity(threads);
+        let first = build_reuseport_listener(addr)?;
+        let local_addr = first.local_addr()?;
+        listeners.push(first);
+        for _ in 1..threads {
+            listeners.push(build_reuseport_listener(local_addr)?);
+        }
+
+        let mut shareds = Vec::with_capacity(threads);
+        let mut joins = Vec::with_capacity(threads);
+        for (i, listener) in listeners.into_iter().enumerate() {
+            let engine = UringEngine::new(listener, cfg.clone(), handler_factory(i))?;
+            shareds.push(engine.shared());
+            let bind_core = cfg
+                .bind_cores
+                .as_ref()
+                .filter(|cores| !cores.is_empty())
+                .map(|cores| cores[i % cores.len()]);
+            let join = std::thread::Builder::new()
+                .name(format!("urpc-uring-{i}"))
+                .spawn(move || {
+                    if let Some(core) = bind_core {
+                        core_affinity::set_for_current(core_affinity::CoreId { id: core as _ });
+                    }
+                    if let Err(e) = engine.run() {
+                        error!("uring urpc engine exited with error: {:#?}", e);
+                    }
+                })?;
+            joins.push(join);
+        }
+
+        Ok(Self {
+            shareds,
+            joins,
+            local_addr,
+        })
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn shutdown(self) {
+        for shared in &self.shareds {
+            shared.stopped.store(true, Ordering::Release);
+            shared.wake();
+        }
+        for join in self.joins {
+            let _ = join.join();
+        }
+    }
+}
+
+fn build_reuseport_listener(addr: SocketAddr) -> Result<TcpListener> {
+    let domain = match addr {
+        SocketAddr::V4(_) => socket2::Domain::IPV4,
+        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    };
+    let sock = socket2::Socket::new(domain, socket2::Type::STREAM, None)?;
+    sock.set_reuse_address(true)?;
+    sock.set_reuse_port(true)?;
+    sock.bind(&addr.into())?;
+    sock.listen(8192)?;
+    Ok(sock.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::urpc::command::RpcResponseCommand;
+    use crate::urpc::frame::MessageType;
+    use bytes::BufMut;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    fn put_string(buf: &mut BytesMut, value: &str) {
+        buf.put_i32(value.len() as i32);
+        buf.put_slice(value.as_bytes());
+    }
+
+    fn build_send_shuffle_data_frame(request_id: i64, payload: &[u8]) -> BytesMut {
+        let mut body = BytesMut::new();
+        body.put_i64(request_id);
+        put_string(&mut body, "app-uring");
+        body.put_i32(7);
+        body.put_i64(99);
+        body.put_i32(1); // partition batch size
+        body.put_i32(11); // partition id
+        body.put_i32(1); // block batch size
+        body.put_i32(11); // pid
+        body.put_i64(1234); // block id
+        body.put_i32(payload.len() as i32); // length
+        body.put_i32(7); // shuffle id
+        body.put_i64(88); // crc
+        body.put_i64(9001); // task attempt id
+        body.put_i32(payload.len() as i32);
+        body.put_slice(payload);
+        body.put_i32(0); // shuffle servers
+        body.put_i32(payload.len() as i32); // uncompress length
+        body.put_i64(0); // free mem
+        body.put_i64(123456); // timestamp
+
+        let mut frame = BytesMut::with_capacity(9 + body.len());
+        frame.put_i32(0);
+        frame.put_u8(MessageType::SendShuffleData as u8);
+        frame.put_i32(body.len() as i32);
+        frame.extend_from_slice(&body);
+        frame
+    }
+
+    async fn read_rpc_response(stream: &mut TcpStream) -> anyhow::Result<(i64, i32, String)> {
+        let mut header = [0u8; 9];
+        stream.read_exact(&mut header).await?;
+        let content_len = i32::from_be_bytes(header[0..4].try_into().unwrap());
+        assert_eq!(MessageType::RpcResponse as u8, header[4]);
+        let body_len = i32::from_be_bytes(header[5..9].try_into().unwrap());
+        assert_eq!(0, body_len);
+
+        let mut content = vec![0u8; content_len as usize];
+        stream.read_exact(&mut content).await?;
+        let request_id = i64::from_be_bytes(content[0..8].try_into().unwrap());
+        let status_code = i32::from_be_bytes(content[8..12].try_into().unwrap());
+        let msg_len = i32::from_be_bytes(content[12..16].try_into().unwrap()) as usize;
+        let msg = String::from_utf8(content[16..16 + msg_len].to_vec())?;
+        Ok((request_id, status_code, msg))
+    }
+
+    fn echo_handler(frame: Frame, responder: &mut Responder<'_>) {
+        match frame {
+            Frame::SendShuffleData(req) => {
+                let resp = Frame::RpcResponse(RpcResponseCommand::new(
+                    req.request_id(),
+                    0,
+                    format!("len={}", req.data_len()),
+                ));
+                responder.respond(&resp).unwrap();
+            }
+            other => panic!("unexpected frame: {other:?}"),
+        }
+    }
+
+    fn start_echo_server() -> UringUrpcServer {
+        UringUrpcServer::start(
+            "127.0.0.1:0".parse().unwrap(),
+            1,
+            UringServerConfig::default(),
+            |_| echo_handler,
+        )
+        .expect("uring server should start")
+    }
+
+    #[tokio::test]
+    async fn echo_small_and_large_frames() -> anyhow::Result<()> {
+        let server = start_echo_server();
+        let mut stream = TcpStream::connect(server.local_addr()).await?;
+
+        // Small frame.
+        let payload = vec![1u8; 128];
+        stream
+            .write_all(&build_send_shuffle_data_frame(1, &payload))
+            .await?;
+        let (request_id, status, msg) = read_rpc_response(&mut stream).await?;
+        assert_eq!(1, request_id);
+        assert_eq!(0, status);
+        assert_eq!("len=128", msg);
+
+        // Large frame spanning many recv operations.
+        let payload = vec![7u8; 4 * 1024 * 1024];
+        stream
+            .write_all(&build_send_shuffle_data_frame(2, &payload))
+            .await?;
+        let (request_id, status, msg) = read_rpc_response(&mut stream).await?;
+        assert_eq!(2, request_id);
+        assert_eq!(0, status);
+        assert_eq!(format!("len={}", payload.len()), msg);
+
+        drop(stream);
+        server.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn echo_pipelined_requests() -> anyhow::Result<()> {
+        let server = start_echo_server();
+        let mut stream = TcpStream::connect(server.local_addr()).await?;
+
+        let count: i64 = 1000;
+        let payload = vec![3u8; 512];
+        let mut batch = BytesMut::new();
+        for id in 0..count {
+            batch.extend_from_slice(&build_send_shuffle_data_frame(id, &payload));
+        }
+        stream.write_all(&batch).await?;
+
+        for id in 0..count {
+            let (request_id, status, _) = read_rpc_response(&mut stream).await?;
+            assert_eq!(id, request_id);
+            assert_eq!(0, status);
+        }
+
+        drop(stream);
+        server.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remote_responder_completes_from_other_thread() -> anyhow::Result<()> {
+        let handler = |frame: Frame, responder: &mut Responder<'_>| {
+            let Frame::SendShuffleData(req) = frame else {
+                panic!("unexpected frame");
+            };
+            let remote = responder.remote();
+            let request_id = req.request_id();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(20));
+                let resp =
+                    Frame::RpcResponse(RpcResponseCommand::new(request_id, 0, "async".into()));
+                remote.respond(&resp).unwrap();
+            });
+        };
+        let server = UringUrpcServer::start(
+            "127.0.0.1:0".parse().unwrap(),
+            1,
+            UringServerConfig::default(),
+            |_| handler,
+        )?;
+
+        let mut stream = TcpStream::connect(server.local_addr()).await?;
+        stream
+            .write_all(&build_send_shuffle_data_frame(42, &[9u8; 64]))
+            .await?;
+        let (request_id, status, msg) = read_rpc_response(&mut stream).await?;
+        assert_eq!(42, request_id);
+        assert_eq!(0, status);
+        assert_eq!("async", msg);
+
+        drop(stream);
+        server.shutdown();
+        Ok(())
+    }
+}

--- a/riffle-server/src/urpc/uring/mod.rs
+++ b/riffle-server/src/urpc/uring/mod.rs
@@ -1,0 +1,12 @@
+//! Pluggable io_uring based urpc net engine.
+//!
+//! This module provides an alternative, completion-driven network stack for
+//! the urpc protocol. It is selected via `urpc_config.net_engine = "URING"`
+//! and requires the `io-uring` cargo feature on linux.
+
+pub mod bridge;
+pub mod encode;
+pub mod engine;
+
+pub use bridge::AppCommandBridgeHandler;
+pub use engine::{FrameHandler, RemoteResponder, Responder, UringServerConfig, UringUrpcServer};

--- a/riffle-server/tests/write_read.rs
+++ b/riffle-server/tests/write_read.rs
@@ -53,4 +53,35 @@ mod tests {
 
         shuffle_testing(&config, _app_ref).await
     }
+
+    #[cfg(all(feature = "io-uring", target_os = "linux"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shuffle_write_read_with_uring_net_engine_testing() -> Result<()> {
+        use riffle_server::config::{RpcVersion, UrpcConfig, UrpcNetEngine};
+
+        init_logger();
+        let temp_dir = tempdir::TempDir::new("test_write_read_uring").unwrap();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+        info!("temp file path: {} created", &temp_path);
+
+        let grpc_port = 21203;
+        let urpc_port = 21204;
+        let mut config =
+            Config::create_mem_localfile_config(grpc_port, "1G".to_string(), temp_path);
+        config.urpc_port = Some(urpc_port);
+        config.urpc_config = Some(UrpcConfig {
+            get_index_rpc_version: RpcVersion::V1,
+            streaming_parse_enabled: true,
+            write_mode: Default::default(),
+            net_engine: UrpcNetEngine::URING,
+        });
+        config.hybrid_store.memory_single_buffer_max_spill_size = Some("1B".to_string());
+        config.localfile_store.as_mut().unwrap().disk_high_watermark = 1.0;
+
+        let _app_ref = mini_riffle::start(&config).await?;
+        // wait all setup
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        shuffle_testing(&config, _app_ref).await
+    }
 }


### PR DESCRIPTION
> This is still experimetal.

## Performance Micro Benchmark

<img width="782" height="169" alt="image" src="https://github.com/user-attachments/assets/55bdb9a8-9cf5-4f16-bcd6-83790ad90ebf" />

Configuration:

- Release build with LTO
- 2 server threads
- 8 client connections
- 3 seconds per case
- 3 consecutive runs
- RPS values are arithmetic means; ranges show min–max
- Throughput is application payload in MiB/s

| Case | Request shape | Tokio RPS | io_uring RPS | RPS change | Speedup | Payload MiB/s (Tokio → io_uring) |
|---|---|---:|---:|---:|---:|---:|
| `block=1KB` | `1 × 1 KiB`, pipeline 64 | 341,127 (334,187–346,283) | 2,491,129 (2,442,304–2,543,360) | +630.3% | **7.303×** | 333.2 → 2,432.8 |
| `block=64KB` | `1 × 64 KiB`, pipeline 16 | 108,745 (105,307–110,528) | 136,450 (124,923–143,397) | +25.5% | **1.255×** | 6,796.6 → 8,528.1 |
| `block=512KB` | `1 × 512 KiB`, pipeline 4 | 22,973 (22,285–24,235) | 22,969 (22,216–24,377) | -0.02% | **1.000×** | 11,486.7 → 11,484.5 |
| `prod=500x10KB` | `500 × 10 KiB`, 500 partitions, ~4.88 MiB/request | 829 (808–846) | 1,253 (1,177–1,316) | +51.1% | **1.511×** | 4,050.0 → 6,118.1 |

## 10TB tpcds Benchmark

### With urpc + uring

<img width="1018" height="909" alt="image" src="https://github.com/user-attachments/assets/08446c49-5a2f-467a-9806-fb97effc75de" />
