### PR TITLE
fix: Use Cranelift to speed up compile when on dev

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[build]
+# Use Cranelift as the codegen backend to speed up dev compilation.
+rustflags = ["-Zcodegen-backend=cranelift"]


### PR DESCRIPTION
Closes #610

Patch generated by `inclusionai/ling-3.0-flash:free` via OpenRouter.