### PR TITLE
fix(hdrs): propagate HDFS file close errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "hdrs"
 version = "0.3.2"
-source = "git+https://github.com/zuston/hdrs?rev=e1f7167adc61198b82bf0fa70b17f4565f1d3a21#e1f7167adc61198b82bf0fa70b17f4565f1d3a21"
+source = "git+https://github.com/zuston/hdrs?rev=515deba88286d032445336ad6acc4922f73d5747#515deba88286d032445336ad6acc4922f73d5747"
 dependencies = [
  "errno",
  "hdfs-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ governor = "0.10.0"
 hashlink = "0.9.1"
 hdfs-native = "0.14.3"
 hdrhistogram = "7.5.4"
-hdrs = { git = "https://github.com/zuston/hdrs", rev = "e1f7167adc61198b82bf0fa70b17f4565f1d3a21" }
+hdrs = { git = "https://github.com/zuston/hdrs", rev = "515deba88286d032445336ad6acc4922f73d5747" }
 hyper = "0.14"
 indicatif = "0.17.11"
 jemalloc_pprof = "0.7.0"

--- a/riffle-server/src/store/hadoop/hdrs.rs
+++ b/riffle-server/src/store/hadoop/hdrs.rs
@@ -57,6 +57,7 @@ impl HdfsClient for HdrsClient {
             .write(true)
             .open(path.as_str())?;
         file.flush()?;
+        file.close()?;
         Ok(())
     }
 
@@ -66,6 +67,7 @@ impl HdfsClient for HdrsClient {
         let mut file = client.open_file().append(true).open(path.as_str())?;
         file.write_all(&data.freeze())?;
         file.flush()?;
+        file.close()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Background

Riffle previously relied on `Drop` to close files opened through `hdrs`. Since Rust's `Drop` implementation cannot return errors, failures from `hdfsCloseFile` were silently ignored.

As a result, Riffle could treat an append as successful and release the in-memory spill data even when HDFS failed to finalize the output stream. Subsequent appends could encounter stale leases or `AlreadyBeingCreatedException`, while shuffle readers could observe missing index entries and report inconsistent block counts.

## Solution

Upgrade `hdrs` to a revision that provides a fallible `File::close()` API, and explicitly close files after `flush()` in both `touch` and `append`.

Any close failure is now propagated through the HDFS client result and handled by Riffle's existing spill retry mechanism. Riffle retains the spill batch, rolls over to a new file generation, and retries the write instead of silently acknowledging incomplete data.