### PR TITLE
feat(urpc)(uring): disable sendfile/splice mechanism by default

### DIFF
--- a/riffle-server/src/app_manager/request_context.rs
+++ b/riffle-server/src/app_manager/request_context.rs
@@ -1,6 +1,7 @@
 use crate::app_manager::app_configs::AppConfigOptions;
 use crate::app_manager::partition_identifier::PartitionUId;
 use crate::app_manager::purge_event::PurgeReason;
+use crate::config::UrpcNetEngine;
 use crate::id_layout::IdLayout;
 use crate::partition_stats::{PartitionStats, TaskToRecordStatRef};
 use crate::store::local::read_options::IoMode;
@@ -132,7 +133,7 @@ pub struct ReadingViewContext {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RpcType {
     GRPC,
-    URPC,
+    URPC(UrpcNetEngine),
 }
 
 impl ReadingViewContext {

--- a/riffle-server/src/store/localfile.rs
+++ b/riffle-server/src/store/localfile.rs
@@ -20,7 +20,7 @@ use crate::app_manager::request_context::{
     PurgeDataContext, ReadingIndexViewContext, ReadingOptions, ReadingViewContext,
     RegisterAppContext, ReleaseTicketContext, RequireBufferContext, RpcType, WritingViewContext,
 };
-use crate::config::{LocalfileStoreConfig, StorageType};
+use crate::config::{LocalfileStoreConfig, StorageType, UrpcNetEngine};
 use crate::error::WorkerError;
 use crate::metric::{
     GAUGE_LOCAL_DISK_SERVICE_USED, LCOALFILE_GET_DATA_RPC_LATENCY_HISTOGRAM_WITH_DATA_BYTES,
@@ -496,7 +496,7 @@ impl Store for LocalFileStore {
 
                 // determine to use which io_mode. having the following limitations
                 // 1. io_mode==DIRECT_IO, this is only valid when append use the direct_io mode!
-                // 2. sendfile + splice are only valid in urpc
+                // 2. sendfile + splice are only valid with the tokio urpc transport
                 let io_mode = if matches!(io_mode, IoMode::DIRECT_IO) {
                     if !self.direct_io_append_enable {
                         debug!("Fallback DIRECT_IO to BUFFER_IO due to append mode mismatch");
@@ -505,9 +505,10 @@ impl Store for LocalFileStore {
                         io_mode
                     }
                 } else {
-                    if matches!(rpc_source, RpcType::URPC) {
+                    if matches!(rpc_source, RpcType::URPC(UrpcNetEngine::TOKIO)) {
                         io_mode
                     } else {
+                        // todo: support sendfile/splice for urpc uring mechanism
                         io_mode.fallback(vec![IoMode::SPLICE, IoMode::SENDFILE], IoMode::BUFFER_IO)
                     }
                 };
@@ -705,13 +706,13 @@ mod test {
     use crate::app_manager::application_identifier::ApplicationId;
     use crate::app_manager::partition_identifier::PartitionUId;
     use crate::app_manager::purge_event::PurgeReason;
-    use crate::config::LocalfileStoreConfig;
+    use crate::config::{LocalfileStoreConfig, UrpcNetEngine};
     use crate::error::WorkerError;
     use crate::runtime::manager::RuntimeManager;
     use crate::store::index_codec::{IndexBlock, IndexCodec, INDEX_BLOCK_SIZE};
     use crate::store::local::read_options::IoMode;
     use crate::store::local::LocalDiskStorage;
-    use crate::store::{Block, ResponseData, ResponseDataIndex, Store};
+    use crate::store::{Block, DataBytes, ResponseData, ResponseDataIndex, Store};
     use bytes::{Buf, Bytes, BytesMut};
     use log::{error, info};
 
@@ -742,6 +743,28 @@ mod test {
         );
 
         writing_ctx
+    }
+
+    #[test]
+    fn uring_urpc_disables_sendfile() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let local_store = LocalFileStore::new(vec![temp_dir.path().display().to_string()]);
+        let runtime = local_store.runtime_manager.clone();
+        let writing_ctx = create_writing_ctx();
+        let uid = writing_ctx.uid.clone();
+        let data_size = writing_ctx.data_size as i64;
+
+        runtime.wait(local_store.insert(writing_ctx))?;
+        let reading_ctx = ReadingViewContext::new(
+            uid,
+            ReadingOptions::FILE_OFFSET_AND_LEN(0, data_size),
+            RpcType::URPC(UrpcNetEngine::URING),
+        )
+        .with_io_mode(IoMode::SENDFILE);
+
+        let data = runtime.wait(local_store.get(reading_ctx))?.from_local();
+        assert!(matches!(data, DataBytes::Direct(_)));
+        Ok(())
     }
 
     #[test]

--- a/riffle-server/src/urpc/command.rs
+++ b/riffle-server/src/urpc/command.rs
@@ -5,7 +5,7 @@ use crate::app_manager::request_context::{
     ReadingIndexViewContext, ReadingOptions, ReadingViewContext, RpcType, WritingViewContext,
 };
 use crate::app_manager::AppManagerRef;
-use crate::config::RpcVersion;
+use crate::config::{RpcVersion, UrpcNetEngine};
 use crate::constant::StatusCode;
 use crate::metric::{
     RPC_BATCH_BYTES_OPERATION, RPC_BATCH_DATA_BYTES_HISTOGRAM, URPC_SEND_DATA_TRANSPORT_TIME,
@@ -51,7 +51,11 @@ impl Command {
     /// Computes the response frame of this command. This is the net-engine
     /// agnostic part shared by the default tokio server and the io_uring
     /// engine bridge.
-    pub async fn process(self, app_manager_ref: AppManagerRef) -> Result<Frame> {
+    pub async fn process(
+        self,
+        app_manager_ref: AppManagerRef,
+        urpc_engine: UrpcNetEngine,
+    ) -> Result<Frame> {
         match self {
             Command::Send(req) => {
                 req.process(app_manager_ref)
@@ -59,7 +63,7 @@ impl Command {
                     .await
             }
             Command::GetMem(req) => {
-                req.process(app_manager_ref)
+                req.process(app_manager_ref, urpc_engine)
                     .instrument_await("applying the command of [GetMemory]")
                     .await
             }
@@ -69,17 +73,17 @@ impl Command {
                     .await
             }
             Command::GetLocalData(req) => {
-                req.process(app_manager_ref)
+                req.process(app_manager_ref, urpc_engine)
                     .instrument_await("applying the command of [GetLocalData]")
                     .await
             }
             Command::GetLocalDataV2(req) => {
-                req.process(app_manager_ref)
+                req.process(app_manager_ref, urpc_engine)
                     .instrument_await("applying the command of [GetLocalDataV2]")
                     .await
             }
             Command::GetLocalDataV3(req) => {
-                req.process(app_manager_ref)
+                req.process(app_manager_ref, urpc_engine)
                     .instrument_await("applying the command of [GetLocalDataV3]")
                     .await
             }
@@ -92,7 +96,7 @@ impl Command {
         conn: &mut Connection,
         _shutdown: &mut Shutdown,
     ) -> Result<()> {
-        let frame = self.process(app_manager_ref).await?;
+        let frame = self.process(app_manager_ref, UrpcNetEngine::TOKIO).await?;
         conn.write_frame(&frame)
             .instrument_await("writing the response...")
             .await?;
@@ -113,7 +117,11 @@ pub struct GetMemoryDataRequestCommand {
 }
 
 impl GetMemoryDataRequestCommand {
-    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
+    pub(crate) async fn process(
+        &self,
+        app_manager_ref: AppManagerRef,
+        urpc_engine: UrpcNetEngine,
+    ) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -142,7 +150,7 @@ impl GetMemoryDataRequestCommand {
                 last_block_id,
                 read_buffer_size as i64,
             ),
-            RpcType::URPC,
+            RpcType::URPC(urpc_engine),
         );
         let ctx = match &self.expected_tasks_bitmap_raw {
             Some(raw) => {
@@ -274,7 +282,11 @@ pub struct ReadSegment {
 }
 
 impl GetLocalDataRequestV2Command {
-    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
+    pub(crate) async fn process(
+        &self,
+        app_manager_ref: AppManagerRef,
+        urpc_engine: UrpcNetEngine,
+    ) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -303,7 +315,7 @@ impl GetLocalDataRequestV2Command {
         let ctx = ReadingViewContext::new(
             uid,
             ReadingOptions::FILE_OFFSET_AND_LEN(offset, length as i64),
-            RpcType::URPC,
+            RpcType::URPC(urpc_engine),
         );
         let mut len = 0;
         let read_timer = Instant::now();
@@ -353,7 +365,11 @@ impl GetLocalDataRequestV2Command {
 }
 
 impl GetLocalDataRequestV3Command {
-    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
+    pub(crate) async fn process(
+        &self,
+        app_manager_ref: AppManagerRef,
+        urpc_engine: UrpcNetEngine,
+    ) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -382,7 +398,7 @@ impl GetLocalDataRequestV3Command {
         let ctx = ReadingViewContext::new(
             uid,
             ReadingOptions::FILE_OFFSET_AND_LEN(offset, length as i64),
-            RpcType::URPC,
+            RpcType::URPC(urpc_engine),
         )
         .with_localfile_next_read_segments(self.next_read_segments.clone())
         .with_task_id(self.task_id);
@@ -431,7 +447,11 @@ impl GetLocalDataRequestV3Command {
 }
 
 impl GetLocalDataRequestCommand {
-    pub(crate) async fn process(&self, app_manager_ref: AppManagerRef) -> Result<Frame> {
+    pub(crate) async fn process(
+        &self,
+        app_manager_ref: AppManagerRef,
+        urpc_engine: UrpcNetEngine,
+    ) -> Result<Frame> {
         let timer = Instant::now();
 
         let request_id = self.request_id;
@@ -458,7 +478,7 @@ impl GetLocalDataRequestCommand {
         let ctx = ReadingViewContext::new(
             uid,
             ReadingOptions::FILE_OFFSET_AND_LEN(offset, length as i64),
-            RpcType::URPC,
+            RpcType::URPC(urpc_engine),
         );
         let mut len = 0;
         let command = match app

--- a/riffle-server/src/urpc/uring/bridge.rs
+++ b/riffle-server/src/urpc/uring/bridge.rs
@@ -2,6 +2,7 @@
 //! processing logic.
 
 use crate::app_manager::AppManagerRef;
+use crate::config::UrpcNetEngine;
 use crate::runtime::RuntimeRef;
 use crate::store::DataBytes;
 use crate::urpc::command::Command;
@@ -43,7 +44,7 @@ impl FrameHandler for AppCommandBridgeHandler {
         let app_manager = self.app_manager.clone();
         self.runtime.spawn(async move {
             let _tracker = tracker;
-            match command.process(app_manager).await {
+            match command.process(app_manager, UrpcNetEngine::URING).await {
                 Ok(frame) => match materialize_frame_data(frame) {
                     Ok(frame) => {
                         if let Err(e) = remote.respond(&frame) {


### PR DESCRIPTION
We haven't implemented the `sendfile` / `splice` for the uring + urpc engine, so disable this mechanism by default. 