### PR TITLE
feat: configure TCP keepalive for server connections

### DIFF
--- a/riffle-server/src/rpc.rs
+++ b/riffle-server/src/rpc.rs
@@ -20,11 +20,14 @@ use once_cell::sync::Lazy;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroUsize;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::{Receiver, Sender};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
+
+pub(crate) const TCP_KEEPALIVE_IDLE: Duration = Duration::from_secs(5 * 60);
 
 pub static GRPC_PARALLELISM: Lazy<NonZeroUsize> = Lazy::new(|| {
     let available_cores = std::thread::available_parallelism().unwrap();
@@ -367,6 +370,7 @@ async fn grpc_serve(
     Server::builder()
         .initial_connection_window_size(MAX_CONNECTION_WINDOW_SIZE)
         .initial_stream_window_size(STREAM_WINDOW_SIZE)
+        .tcp_keepalive(Some(TCP_KEEPALIVE_IDLE))
         .tcp_nodelay(true)
         .layer(TracingMiddleWareLayer::new())
         .layer(MetricsMiddlewareLayer::new(GRPC_LATENCY_TIME_SEC.clone()))

--- a/riffle-server/src/urpc/server.rs
+++ b/riffle-server/src/urpc/server.rs
@@ -16,11 +16,12 @@ use crate::error::WorkerError;
 use crate::metric::{
     TOTAL_GRPC_REQUEST, TOTAL_URPC_REQUEST, URPC_CONNECTION_NUMBER, URPC_REQUEST_PROCESSING_LATENCY,
 };
+use crate::rpc::TCP_KEEPALIVE_IDLE;
 use crate::urpc::command::Command;
 use crate::urpc::metrics::RequestMetricTracker;
 use anyhow::Result;
 use await_tree::InstrumentAwait;
-use socket2::SockRef;
+use socket2::{SockRef, TcpKeepalive};
 use tracing::Instrument;
 
 const MAX_CONNECTIONS: usize = 200000;
@@ -86,9 +87,9 @@ impl Listener {
         loop {
             match self.listener.accept().await {
                 Ok((socket, _)) => {
-                    // todo: fine-grained keep_alive options
                     let sock_ref = SockRef::from(&socket);
-                    sock_ref.set_keepalive(true)?;
+                    sock_ref
+                        .set_tcp_keepalive(&TcpKeepalive::new().with_time(TCP_KEEPALIVE_IDLE))?;
                     sock_ref.set_nodelay(true)?;
                     return Ok(socket);
                 }

--- a/riffle-server/src/urpc/uring/engine.rs
+++ b/riffle-server/src/urpc/uring/engine.rs
@@ -2,6 +2,7 @@
 
 use crate::error::WorkerError;
 use crate::metric::{URPC_CONNECTION_NUMBER, URPC_REQUEST_PARSING_LATENCY};
+use crate::rpc::TCP_KEEPALIVE_IDLE;
 use crate::store::DataBytes;
 use crate::urpc::frame::{get_i32, get_u8, Frame};
 use anyhow::{anyhow, Context, Result};
@@ -493,6 +494,7 @@ impl<H: FrameHandler> UringEngine<H> {
 
         unsafe {
             let one: libc::c_int = 1;
+            let keepalive_idle_secs = TCP_KEEPALIVE_IDLE.as_secs() as libc::c_int;
             libc::setsockopt(
                 fd,
                 libc::IPPROTO_TCP,
@@ -505,6 +507,13 @@ impl<H: FrameHandler> UringEngine<H> {
                 libc::SOL_SOCKET,
                 libc::SO_KEEPALIVE,
                 &one as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_TCP,
+                libc::TCP_KEEPIDLE,
+                &keepalive_idle_secs as *const _ as *const libc::c_void,
                 std::mem::size_of::<libc::c_int>() as libc::socklen_t,
             );
         }


### PR DESCRIPTION
## Problem

Under high connection churn, Riffle may retain a large number of established connections after clients become unreachable. On one production server, this resulted in approximately 289,000 established TCP connections and 292,000 open file descriptors, significantly increasing memory and FD pressure.

The gRPC server did not enable TCP keepalive. The Tokio and io_uring uRPC implementations enabled `SO_KEEPALIVE`, but did not configure `TCP_KEEPIDLE`, so they inherited the Linux default of 7,200 seconds. Dead connections could therefore remain for more than two hours before being detected.

## Solution

Introduce a shared five-minute TCP keepalive idle duration in `rpc.rs` and apply it consistently to:

- The Tonic gRPC server.
- The Tokio uRPC server.
- The io_uring uRPC server.